### PR TITLE
Further improvements to error tooltip

### DIFF
--- a/browser/src/UI/Overlay/WindowContext.ts
+++ b/browser/src/UI/Overlay/WindowContext.ts
@@ -113,6 +113,9 @@ export class WindowContext {
         // It would be much easier if we could just ask neovim to give this to say how much the offset is, but I haven't found how so far
     }
 
+    /**
+     * Returns position of window line + column in pixels on the screen
+     */
     public getWindowPosition(windowline: number, column: number): Rectangle {
         const linePosition = this.getWindowRegionForLine(windowline)
 

--- a/browser/src/UI/Overlay/WindowContext.ts
+++ b/browser/src/UI/Overlay/WindowContext.ts
@@ -58,11 +58,11 @@ export class WindowContext {
         return typeof this._lineMapping[line] === "number"
     }
 
-    public getCurrentWindowLine(): number {
+    public getCurrentScreenLine(): number {
         return this._eventContext.winline
     }
 
-    public getWindowLine(bufferLine: number): number {
+    public getStartScreenLineFromBufferLine(bufferLine: number): number {
         return this._lineMapping[bufferLine]
     }
 
@@ -76,13 +76,56 @@ export class WindowContext {
             height: this._fontHeightInPixels, // TODO
         }
     }
+    /**
+     * Returns the amount of columns available for writing (so NOT including the column for eg. line numbers) in the current window/split
+     */
+    public getColumnsPerScreenLine(): number {
+        return this._dimensions.width - this.getColumnOffset()
+    }
 
-    public getWindowPosition(line: number, column: number): Rectangle {
-        const linePosition = this.getWindowRegionForLine(line)
-        const columnPosition = (this._eventContext.wincol - this._eventContext.column + column - 1) * this._fontWidthInPixels
+    /**
+     * Returns the current column of the cursor, based on window lines
+     * This means that if your columns wrap at 80 and your cursor is on column 90 of a line,
+     * this will return 90. This is in contrast to _eventContext.wincol, which would give you 10 + offset
+     */
+    public getCurrentWindowColumn(): number {
+        return this._eventContext.column
+    }
+
+    /**
+     * Returns the columns on the left side that are "lost" (ie you can't write on them) because of eg. numbers, gutter, ...
+     */
+    public getColumnOffset(): number {
+        const currentLineStartsOnScreenLine = this._lineMapping[this._eventContext.line]
+        const currentScreenLine = this._eventContext.winline
+        const wrappedLines = currentScreenLine - currentLineStartsOnScreenLine
+
+        // We have two unknown variables: 
+        // * the linenumbers column offset, named "offset"
+        // * and the amount of columns per line, named "columnsPerScreenLine"
+        // The following 2 equations always hold, so we can use these to determine both variables:
+        // this._eventContext.column - wrappedLines * columnsPerScreenLine = this._eventContext.wincol - offset
+        // offset + columnsPerScreenLine = this._dimensions.width
+        // High school algebra then gets us:
+        const offset = (this._eventContext.wincol - this._eventContext.column + wrappedLines * this._dimensions.width) / (wrappedLines + 1)
+        return offset
+
+        // It would be much easier if we could just ask neovim to give this to say how much the offset is, but I haven't found how so far
+    }
+
+    public getWindowPosition(windowline: number, column: number): Rectangle {
+        const linePosition = this.getWindowRegionForLine(windowline)
+
+        const columnsPerScreenLine = this.getColumnsPerScreenLine()
+        // adding + 1 to columnsPerScreenLine because a page of eg. 85 wraps at 86
+        const linesWrapped = Math.floor(column / (columnsPerScreenLine + 1))
+
+        const columnPosition = (column - (linesWrapped * columnsPerScreenLine) + this.getColumnOffset())
+        const columnPositionInPixels = (columnPosition - 1) * this._fontWidthInPixels // -1 Because it's more natural to indicate an x coordinate in front of it's cell than after it
+
         return {
-            x: linePosition.x + columnPosition,
-            y: linePosition.y,
+            x: columnPositionInPixels,
+            y: linePosition.y + linesWrapped * this._fontHeightInPixels,
             width: this._fontWidthInPixels,
             height: this._fontHeightInPixels,
         }

--- a/browser/src/UI/components/Error.less
+++ b/browser/src/UI/components/Error.less
@@ -53,21 +53,64 @@
     &:before{
         content: "";
         position: absolute;
-        left: -7px;
-        top: -7px;
         border: 4px solid;
-        border-top-color: transparent;
-        border-right-color: transparent;
-        border-bottom-color: inherit;
-        border-left-color: inherit;
     }
+}
+.error.left {
+    border-left: 0px;
+    border-right: 7px solid;
+}
+.error:before{
+    top: -7px;
+    bottom: initial;
+    left: -7px;
+    right: initial;
+
+    border-top-color: transparent;
+    border-bottom-color: inherit;
+    border-right-color: transparent;
+    border-left-color: inherit;
+
+    margin-top: 0px;
 }
 .error.top:before{
     top: initial;
     bottom: -7px;
+    left: -7px;
+    right: initial;
+
     border-top-color: inherit;
     border-bottom-color: transparent;
+    border-right-color: transparent;
+    border-left-color: inherit;
+
     margin-top: -31px;
+}
+.error.left:before{
+    top: -7px;
+    bottom: initial;
+    left: initial;
+    right: -7px;
+
+    border-top-color: transparent;
+    border-bottom-color: inherit;
+    border-right-color: inherit;
+    border-left-color: transparent;
+
+    margin-top: 0px;
+}
+.error.top.left:before{
+    top: initial;
+    bottom: -7px;
+    left: initial;
+    right: -7px;
+
+    border-top-color: inherit;
+    border-bottom-color: transparent;
+    border-right-color: inherit;
+    border-left-color: transparent;
+
+    margin-top: 0px;
 }
 .error.active{
     opacity: 1;

--- a/browser/src/UI/components/Error.tsx
+++ b/browser/src/UI/components/Error.tsx
@@ -48,7 +48,7 @@ export class Errors extends React.Component<IErrorsProps, void> {
                 color = es[0].color
             }
             if (this.props.windowContext.isLineInView(es[0].lineNumber)) {
-                // startScreenLine && currentScreenLine can be same windowLine,
+                // startScreenLine && currentScreenLine can be same windowLine
                 // if the current windowLine is wrapping around
                 const columnsPerScreenLine = this.props.windowContext.getColumnsPerScreenLine()
                 const currentWindowColumn = this.props.windowContext.getCurrentWindowColumn()
@@ -58,10 +58,14 @@ export class Errors extends React.Component<IErrorsProps, void> {
                 const windowSizeInPixels = this.props.windowContext.dimensions.height * this.props.windowContext.fontHeightInPixels
                 const showTooltipTop = windowSizeInPixels - yPos < 80
 
+                const windowWidthInPixels = this.props.windowContext.dimensions.width * this.props.windowContext.fontWidthInPixels
+                const showTooltipLeft = windowWidthInPixels - xPos < 250
+
                 return <ErrorMarker isActive={isActive}
                     x={xPos}
                     y={yPos}
                     showTooltipTop={showTooltipTop}
+                    showTooltipLeft={showTooltipLeft}
                     text={text}
                     color={color}/>
             } else {
@@ -96,6 +100,7 @@ export interface IErrorMarkerProps {
     x: number
     y: number
     showTooltipTop: boolean
+    showTooltipLeft: boolean
     text: string[]
     isActive: boolean
     color: string
@@ -111,7 +116,8 @@ export class ErrorMarker extends React.Component<IErrorMarkerProps, void> {
             top: this.props.y.toString() + "px",
         }
         const textPositionStyles = {
-            left: this.props.x.toString() + "px",
+            left: this.props.showTooltipLeft ? "initial" : this.props.x.toString() + "px",
+            right: this.props.showTooltipLeft ? "calc(100% - " + this.props.x.toString() + "px" : "initial",
             // Tooltip below line: use top so text grows downward when text gets longer
             // Tooltip above line: use bottom so text grows upward
             top: this.props.showTooltipTop ? "initial" : this.props.y.toString() + "px",
@@ -123,6 +129,7 @@ export class ErrorMarker extends React.Component<IErrorMarkerProps, void> {
             "error",
             this.props.isActive ? "active" : "",
             this.props.showTooltipTop ? "top" : "",
+            this.props.showTooltipLeft ? "left" : "",
         ].join(" ")
 
         const texts = _.map(this.props.text, (t) => {

--- a/browser/src/UI/components/Error.tsx
+++ b/browser/src/UI/components/Error.tsx
@@ -71,18 +71,17 @@ export class Errors extends React.Component<IErrorsProps, void> {
 
         const squiggles = errors.map((e) => {
             if (this.props.windowContext.isLineInView(e.lineNumber) && e.endColumn) {
-                // const screenLine = this.props.windowContext.getWindowLine(e.lineNumber)
-
-                const yPos = this.props.windowContext.getWindowRegionForLine(e.lineNumber).y
-
-                const startX = this.props.windowContext.getWindowPosition(e.lineNumber, e.startColumn as any).x // FIXME: undefined
+                const startX = this.props.windowContext.getWindowPosition(e.lineNumber, e.startColumn).x
                 const endX = this.props.windowContext.getWindowPosition(e.lineNumber, e.endColumn).x
+                const width = _.max([endX - startX, 1 * this.props.windowContext.fontWidthInPixels])
+
+                const yPos = this.props.windowContext.getWindowPosition(e.lineNumber, e.startColumn).y
 
                 return <ErrorSquiggle
                     y={yPos}
                     height={this.props.windowContext.fontHeightInPixels}
                     x={startX}
-                    width={endX - startX}
+                    width={width}
                     color={e.color}/>
             } else {
                 return null


### PR DESCRIPTION
I added some more improvements to the Errors component. The commits explain pretty well what's going on.

Commit 1 groups errors on the same line together. It just takes the most left message as the place where to put the arrow. The color gets decided kinda at random. I think the IErrorWithColor interface should rather have something like a severity (info, warning, error) so we can pick the color more intelligently. Screenshot: 

<img width="590" alt="screen shot 2017-04-14 at 11 41 47" src="https://cloud.githubusercontent.com/assets/4463490/25040041/626a3ac4-2107-11e7-823f-a6f5496c2338.png">

Commit 2 is the gnarliest one. There were a few problems with errors not being shown, or shown at the wrong place, when lines get wrapped. I think I fixed them all. The hardest part is keeping the 3 kinds of "lines" and "columns" apart. I tried to make it as consistent as possible, using the following names: 

* "Buffer" lines & columns are just the lines in the file, irrespective of what we're rendering, wrapping, whatever. Compilers, linters etc emit their messages with these kind of lines & columns.
* "Window" lines & columns. These are the same as Buffer lines, but 1-indexed from the top of the screen.
* "Screen" lines & columns. These are also 1-indexed from the top, but stricltly look at how the text is layed out. So if one buffer line is wrapped over 3 lines in the editor, it means it takes 3 screen lines.

Also getting a hold of the "offset" on the left side of the screen caused by eg. ```set numbers``` is awful, so I had to deduced it from the info I did have. If we could just ask that to neovim that would be much easier!

Commit 3: Squiggles were not shown correctly on wrapped lines + when startColumn and endColumn were the same, nothing was shown. You pretty much always want something to be shown imo, so I added a "minimum" squiggle of width = 1 cell.

Commit 4: Using the above functions from Commit 3, I added support for showing errors to the left if there is not enough real estate on the right side.

<img width="873" alt="screen shot 2017-04-14 at 11 51 04" src="https://cloud.githubusercontent.com/assets/4463490/25040292/af6a2d7e-2108-11e7-9f25-505301a5fd71.png">

Phew!