### PR TITLE
Bump electron version to 1.7.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -136,7 +136,7 @@
     "concurrently": "3.1.0",
     "cross-env": "3.1.3",
     "css-loader": "0.28.4",
-    "electron": "1.7.7",
+    "electron": "1.7.8",
     "electron-builder": "19.26.0",
     "electron-devtools-installer": "2.2.0",
     "electron-rebuild": "1.6.0",


### PR DESCRIPTION
Upgrade electron to 1.7.8 to pick up RCE security fix