### PR TITLE
Fix multibyte character rendering

### DIFF
--- a/browser/src/Renderer/CanvasRenderer.ts
+++ b/browser/src/Renderer/CanvasRenderer.ts
@@ -166,7 +166,8 @@ export class CanvasRenderer implements INeovimRenderer {
 
         if (cell.foregroundColor !== currentState.foregroundColor
             || cell.backgroundColor !== currentState.backgroundColor
-            || isCurrentCellWhiteSpace !== currentState.isWhitespace) {
+            || isCurrentCellWhiteSpace !== currentState.isWhitespace
+            || cell.characterWidth > 1) {
             return {
                 isWhitespace: isCurrentCellWhiteSpace,
                 foregroundColor: cell.foregroundColor,


### PR DESCRIPTION
While working on #716, there was a pretty glaring issue with multibyte character rendering - the spacing is not correct. 

When the multibyte characters are combined in a string and rendered on the canvas, the spacing is not as expected in Vim's monospace grid. A quick fix for this is to render the multibyte characters individual.