### PR TITLE
Refactor handling of arguments to child process

### DIFF
--- a/cli/oni
+++ b/cli/oni
@@ -8,6 +8,7 @@ var fs = require("fs")
 var processOptions = {}
 processOptions.detached = true
 processOptions.stdio = ["ignore", null, null]
+processOptions.env = Object.assign({}, process.env, { "LOCAL_ONI": 1 })
 
 var isWindows = os.platform() === "win32";
 

--- a/main/src/main.ts
+++ b/main/src/main.ts
@@ -157,13 +157,8 @@ function focusNextInstance(direction) {
 }
 
 function loadFileFromArguments(platform, args, workingDirectory) {
-    const windowsOpenWith = platform === "win32" &&
-                            args[0].split("\\").pop() === "Oni.exe"
-
-    const macOpenWith = platform === "darwin" &&
-                            args[0].indexOf("Oni.app") >= 0
-
-    if (windowsOpenWith || macOpenWith) {
+    const localOni = "LOCAL_ONI"
+    if (!process.env[localOni]) {
         createWindow(args.slice(1), workingDirectory)
     } else {
         createWindow(args.slice(2), workingDirectory)


### PR DESCRIPTION
Use the `LOCAL_ONI` environment variable instead of checking the platform and file name of the electron executable.

Also diminishes the surface area of places where there's need to check the running platorm, making cross-platform support easier.

Fix #725