### PR TITLE
Handle `onDidChangeKeyboardLayout` event

### DIFF
--- a/browser/src/Event.ts
+++ b/browser/src/Event.ts
@@ -31,7 +31,7 @@ export class Event<T> implements IEvent<T> {
         return { dispose }
     }
 
-    public dispatch(val: T): void {
+    public dispatch(val?: T): void {
         this._eventObject.emit(this._name, val)
     }
 }

--- a/browser/src/Input/Keyboard/Keyboard.ts
+++ b/browser/src/Input/Keyboard/Keyboard.ts
@@ -3,11 +3,19 @@ import * as Log from "./../../Log"
 import { keyboardLayout } from "./KeyboardLayout"
 import { createMetaKeyResolver, ignoreMetaKeyResolver, KeyResolver, remapResolver  } from "./Resolvers"
 
-const resolvers: KeyResolver[] = [
-    ignoreMetaKeyResolver,
-    remapResolver,
-    createMetaKeyResolver(keyboardLayout.getCurrentKeyMap()),
-]
+const rebuildResolvers = (): KeyResolver[] => {
+    return [
+        ignoreMetaKeyResolver,
+        remapResolver,
+        createMetaKeyResolver(keyboardLayout.getCurrentKeyMap()),
+    ]
+}
+
+let resolvers: KeyResolver[] = rebuildResolvers()
+
+keyboardLayout.onKeyMapChanged.subscribe(() => {
+    resolvers = rebuildResolvers()
+})
 
 export const keyEventToVimKey = (evt: KeyboardEvent): string | null => {
     const mappedKey = resolvers.reduce((prev: string, current) => {
@@ -22,3 +30,4 @@ export const keyEventToVimKey = (evt: KeyboardEvent): string | null => {
 
     return mappedKey
 }
+

--- a/browser/src/Input/Keyboard/Keyboard.ts
+++ b/browser/src/Input/Keyboard/Keyboard.ts
@@ -30,4 +30,3 @@ export const keyEventToVimKey = (evt: KeyboardEvent): string | null => {
 
     return mappedKey
 }
-

--- a/browser/src/Input/Keyboard/KeyboardLayout.ts
+++ b/browser/src/Input/Keyboard/KeyboardLayout.ts
@@ -1,3 +1,5 @@
+import { Event, IEvent } from "./../../Event"
+
 export interface IKeyMap {
     [key: string]: IKeyInfo
 }
@@ -11,11 +13,29 @@ export interface IKeyInfo {
 
 class KeyboardLayoutManager {
     private _keyMap: IKeyMap = null
+    private _onKeyMapChanged: Event<void> = new Event<void>()
+
+    /**
+     * Event that is triggered when the keymap is changed,
+     * ie, when the keyboard layout is changed externally
+     */
+    public get onKeyMapChanged(): IEvent<void> {
+        return this._onKeyMapChanged
+    }
 
     public getCurrentKeyMap(): IKeyMap {
         if (!this._keyMap) {
             const KeyboardLayout = require("keyboard-layout") // tslint:disable-line no-var-requires
             this._keyMap = KeyboardLayout.getCurrentKeymap()
+
+            // Lazily subscribe to the KeyboardLayout.onDidChangeCurrentKeyboardLayout
+            // This is lazy primarily for unit testing outside of electron (where this module isn't available)
+            KeyboardLayout.onDidChangeCurrentKeyboardLayout((layout: any) => {
+                if (layout) {
+                    this._keyMap = layout
+                    this._onKeyMapChanged.dispatch()
+                }
+            })
         }
 
         return this._keyMap

--- a/browser/src/Input/Keyboard/KeyboardLayout.ts
+++ b/browser/src/Input/Keyboard/KeyboardLayout.ts
@@ -1,4 +1,5 @@
 import { Event, IEvent } from "./../../Event"
+import * as Log from "./../../Log"
 
 export interface IKeyMap {
     [key: string]: IKeyInfo
@@ -26,15 +27,15 @@ class KeyboardLayoutManager {
     public getCurrentKeyMap(): IKeyMap {
         if (!this._keyMap) {
             const KeyboardLayout = require("keyboard-layout") // tslint:disable-line no-var-requires
+            Log.verbose("[Keyboard Layout] " + KeyboardLayout.getCurrentKeyboardLayout())
             this._keyMap = KeyboardLayout.getCurrentKeymap()
 
             // Lazily subscribe to the KeyboardLayout.onDidChangeCurrentKeyboardLayout
             // This is lazy primarily for unit testing outside of electron (where this module isn't available)
-            KeyboardLayout.onDidChangeCurrentKeyboardLayout((layout: any) => {
-                if (layout) {
-                    this._keyMap = layout
-                    this._onKeyMapChanged.dispatch()
-                }
+            KeyboardLayout.onDidChangeCurrentKeyboardLayout((newLayout: string) => {
+                Log.verbose("[Keyboard Layout] " + newLayout)
+                this._keyMap = KeyboardLayout.getCurrentKeymap()
+                this._onKeyMapChanged.dispatch()
             })
         }
 


### PR DESCRIPTION
The `keyboard-layout` module exposes a hook for when the keyboard layout changes. This allows us to update our keymap in response.

Without this change, if you change keyboard layout while using Oni, the previous keymap would still be active.