### PR TITLE
Remove unused .oni folder

### DIFF
--- a/.oni/launch.json
+++ b/.oni/launch.json
@@ -1,9 +1,0 @@
-{
-    "type": "execute",
-    "name": "Oni - Test",
-    "program": "oni",
-    "args": [],
-    "dependentCommands": [
-        "npm run build"
-    ]
-}


### PR DESCRIPTION
The `launch.json` isn't currently used. This should be revisited as part of #68, #686 