### PR TITLE
Fix timing issue with IME background

### DIFF
--- a/browser/src/Editor/KeyboardInput.tsx
+++ b/browser/src/Editor/KeyboardInput.tsx
@@ -165,7 +165,7 @@ class KeyboardInputView extends React.PureComponent<IKeyboardInputViewProps, IKe
     private _onCompositionUpdate(evt: React.CompositionEvent<HTMLInputElement>) {
         if (this._keyboardElement) {
 
-            const measurements = measureFont(this.props.fontSize, this.props.fontFamily, this._keyboardElement.value)
+            const measurements = measureFont(this.props.fontSize, this.props.fontFamily, evt.data)
 
             // Add some padding for an extra character to the end of the input box
             const roomForNextCharacter = this.props.fontCharacterWidthInPixels


### PR DESCRIPTION
The background of the IME editor was not always up-to-date, especially in cases like scrolling through the IME. We need to look at the composition event's `data` instead of the value of the input element.