### PR TITLE
Fix config.js auto-reloading on OSX

### DIFF
--- a/browser/src/Config.ts
+++ b/browser/src/Config.ts
@@ -232,7 +232,8 @@ export class Config {
         // I could use watchFile() but that polls every 5 seconds.  Not ideal.
         if (fs.existsSync(this.getUserFolder())) {
             fs.watch(this.getUserFolder(), (event, filename) => {
-                if (event === "change" && filename === "config.js") {
+                if ((event === "change" && filename === "config.js") ||
+                     (event === "rename" && filename === "config.js")) {
                     // invalidate the Config currently stored in cache
                     delete global["require"].cache[global["require"].resolve(this.userJsConfig)] // tslint:disable-line no-string-literal
                     this.applyConfig()


### PR DESCRIPTION
The `config.js` file was not being auto-reloaded on OSX. It seems a different sequence of `watch` events comes through on OSX (a sequence of renames vs change). This hacks to pick up the change.

Later, we could potentially look at ditching the fs.watch strategy, and just check the post-save event from vim if the buffer matches the expected place for their user config.