### PR TITLE
Fix AltGr regression

### DIFF
--- a/browser/src/UI/RootComponent.tsx
+++ b/browser/src/UI/RootComponent.tsx
@@ -38,8 +38,8 @@ export class RootComponent extends React.PureComponent<IRootComponentProps, void
         </div>
     }
 
-    private _onRootKeyDown(evt: any): void {
-        const vimKey = keyEventToVimKey(evt)
+    private _onRootKeyDown(evt: React.KeyboardEvent<HTMLElement>): void {
+        const vimKey = keyEventToVimKey(evt.nativeEvent)
         if (inputManager.handleKey(vimKey)) {
             evt.stopPropagation()
             evt.preventDefault()

--- a/test/Manual.md
+++ b/test/Manual.md
@@ -1,0 +1,18 @@
+# Manual Test Cases
+
+Ideally, these test cases could be automated to minimize overhead with the release process
+
+## Internationalization
+- German:
+    - [, ] (Alt5,6 on German OSX, Alt7/8 on Windows International)
+    - {} (Alt 8,9 on German OSX, Alt 6,9 on Windows International)
+    - öÖ (: english keyboard)
+    - üÜ ([ english keyboard)
+- Hiragana: 
+    - Oni (鬼)
+    - tekisuto (テキスト)
+- English International: 
+    - `a (`+a)
+    - 'a ('+a)
+    - ß (AltGr+S)
+


### PR DESCRIPTION
Several `AltGr` combinations were regressed, due to a regression in one of the late commits in #716.

The react synthetic event was being passed to our keyboard handler, as opposed to the native event... the synthetic event doesn't have the `code` property, which is needed for our input handling logic. This caused erroneous and problematic results.

Also added a set of manual test cases to run around internationalization. Hopefully some of these could be automated in the future.