### PR TITLE
#490 - Part 1: Add ability to override neovim path

### DIFF
--- a/browser/src/Config.ts
+++ b/browser/src/Config.ts
@@ -24,6 +24,9 @@ export interface IConfigValues {
         columns: number,
     } | null
 
+    // Option to override neovim path. Used for testing new versions before bringing them in.
+    "debug.neovimPath": string | null
+
     // Production settings
 
     // Bell sound effect to use
@@ -130,6 +133,7 @@ export class Config {
         deactivate: noop,
 
         "debug.fixedSize": null,
+        "debug.neovimPath": null,
 
         "oni.audio.bellUrl": path.join(__dirname, "audio", "beep.wav"),
 

--- a/browser/src/neovim/NeovimProcessSpawner.ts
+++ b/browser/src/neovim/NeovimProcessSpawner.ts
@@ -27,6 +27,12 @@ export const startNeovim = (runtimePaths: string[], args: string[]): Session => 
 
     nvimProcessPath = remapPathToUnpackedAsar(nvimProcessPath)
 
+    const neovimPath = Config.instance().getValue("debug.neovimPath")
+
+    if (neovimPath) {
+        nvimProcessPath = neovimPath
+    }
+
     const joinedRuntimePaths = runtimePaths
                                     .map((p) => remapPathToUnpackedAsar(p))
                                     .join(",")


### PR DESCRIPTION
I suspect that the Windows crash is fixed in the latest neovim build, so I want to test it out locally before bumping the neovim version. This change adds the ability to point to a local version of neovim.

The intention is to use this primarily for troubleshooting between versions of Neovim, but not something to be used day-to-day. I'd like to package neovim builds so that it is a friction-free setup (and all the features work out of the box), and potentially look at leveraging a WebAssembly build of Neovim later.