### PR TITLE
Fix #714 - Menu styles + font sizing issues

### DIFF
--- a/browser/src/Config.ts
+++ b/browser/src/Config.ts
@@ -182,7 +182,7 @@ export class Config {
         "environment.additionalPaths": [],
 
         "statusbar.enabled": true,
-        "statusbar.fontSize": "11px",
+        "statusbar.fontSize": "0.9em",
 
         "tabs.enabled": true,
         "tabs.showVimTabs": false,
@@ -190,7 +190,6 @@ export class Config {
 
     private MacConfig: Partial<IConfigValues> = {
         "editor.fontFamily": "Menlo",
-        "statusbar.fontSize": "10px",
         "environment.additionalPaths": [
             "/usr/bin",
             "/usr/local/bin",
@@ -199,12 +198,10 @@ export class Config {
 
     private WindowsConfig: Partial<IConfigValues> = {
         "editor.fontFamily": "Consolas",
-        "statusbar.fontSize": "11px",
     }
 
     private LinuxConfig: Partial<IConfigValues> = {
         "editor.fontFamily": "DejaVu Sans Mono",
-        "statusbar.fontSize": "11px",
         "environment.additionalPaths": [
             "/usr/bin",
             "/usr/local/bin",

--- a/browser/src/UI/components/Menu.less
+++ b/browser/src/UI/components/Menu.less
@@ -6,7 +6,7 @@
     left: 0px;
     bottom: 0px;
     right: 0px;
-    background-color: rgba(0, 0, 0, 0.1);
+    background-color: rgba(0, 0, 0, 0.25);
     display: flex;
     flex-direction: column;
     align-items: center;
@@ -16,20 +16,18 @@
     .box-shadow;
 
     margin-top: 16px;
-    background-color: @background-color;
-    color: @text-color;
     padding: 8px;
-    width: 600px;
-    max-height: 400px;
+    width: 75%;
+    max-width: 900px;
 
     input {
-        color: @text-color;
-        background-color: rgb(60, 60, 60);
-        border: 1px solid rgb(80, 80, 80);
-        font-size: 14px;
+        border: 0px;
+        background-color: rgba(0, 0, 0, 0.2);
+        font-size: 1.1em;
         box-sizing: border-box;
         width: 100%;
-        padding: 4px;
+        padding: 8px;
+        outline: none;
     }
 
     .items {
@@ -45,17 +43,19 @@
             user-select: none;
             -webkit-user-drag: none;
             cursor: pointer;
+            font-size: @font-size-normal;
+            overflow: hidden;
 
             .fa:not(.fa-spin) {
                 padding-right: 8px;
             }
 
             &:hover {
-                background-color: fade(@background-color-highlight, 10%);
+                background-color: rgba(0, 0, 0, 0.2);
             }
             &.selected {
                 .box-shadow;
-                background-color: @background-color-highlight;
+                background-color: rgba(0, 0, 0, 0.2);
             }
 
             .label {
@@ -63,8 +63,8 @@
                 padding-right: 8px;
 
                 .highlight {
-                    color: @text-color-highlight;
                     font-weight: bold;
+                    text-decoration: underline;
                 }
             }
 
@@ -74,8 +74,8 @@
                 flex: 1 1 auto;
 
                 .highlight {
-                    color: @text-color-highlight;
                     font-weight: bold;
+                    text-decoration: underline;
                 }
             }
         }

--- a/browser/src/UI/components/Menu.tsx
+++ b/browser/src/UI/components/Menu.tsx
@@ -26,6 +26,9 @@ export interface IMenuProps {
     onChangeFilterText: (text: string) => void
     onSelect: (openInSplit: string, selectedIndex?: number) => void
     items: State.IMenuOptionWithHighlights[]
+
+    backgroundColor: string
+    foregroundColor: string
 }
 
 export class Menu extends React.PureComponent<IMenuProps, void> {
@@ -57,9 +60,15 @@ export class Menu extends React.PureComponent<IMenuProps, void> {
             onClick={() => this.props.onSelect("e", index)}
             />)
 
+        const menuStyle = {
+            backgroundColor: this.props.backgroundColor,
+            color: this.props.foregroundColor,
+        }
+
         return <div className="menu-background enable-mouse">
-            <div className="menu">
+            <div className="menu" style={menuStyle}>
                 <input type="text"
+                    style={{color: this.props.foregroundColor}}
                     ref={(inputElement) => {
                         this._inputElement = inputElement
                         if (this._inputElement) {
@@ -90,6 +99,8 @@ const mapStateToProps = (state: State.IState) => {
             selectedIndex: 0,
             filterText: "",
             items: EmptyArray,
+            backgroundColor: state.backgroundColor,
+            foregroundColor: state.foregroundColor,
         }
     } else {
         const popupMenu = state.popupMenu
@@ -98,6 +109,8 @@ const mapStateToProps = (state: State.IState) => {
             selectedIndex: popupMenu.selectedIndex,
             filterText: popupMenu.filter,
             items: popupMenu.filteredOptions,
+            backgroundColor: state.backgroundColor,
+            foregroundColor: state.foregroundColor,
         }
     }
 }

--- a/browser/src/UI/components/common.less
+++ b/browser/src/UI/components/common.less
@@ -1,7 +1,8 @@
 // common.less
 
 // Font Size
-@font-size-small: 11px;
+@font-size-normal: 1em;
+@font-size-small: 0.9em;
 
 // Colors
 @text-color: rgb(200, 200, 200);


### PR DESCRIPTION
Address a couple of issues with the menu:
- Use the `foregroundColor` and `backgroundColor` from the current color theme, and no hardcoded colors.
- Use `em` instead of `px` for font-sizes here, since `px` doesn't work correctly for HDPI displays. We should use `pt` as the font sizes.

Remaining issues:
- [x] Update default font size to `pt` on Linux/Mac