### PR TITLE
Fix #746 - Fix dead keys in command line / normal mode

### DIFF
--- a/browser/src/Editor/KeyboardInput.tsx
+++ b/browser/src/Editor/KeyboardInput.tsx
@@ -30,6 +30,12 @@ interface IKeyboardInputViewProps {
 }
 
 interface IKeyboardInputViewState {
+
+    /**
+     * Tracks if a dead key has been pressed, in which we should use the `input` strategy
+     */
+    isDead: boolean
+
     /**
      * Tracks if composition is occurring (ie, an IME is active)
      */
@@ -59,6 +65,7 @@ class KeyboardInputView extends React.PureComponent<IKeyboardInputViewProps, IKe
         super()
 
         this.state = {
+            isDead: false,
             isComposing: false,
             compositionTextWidthInPixels: 0,
         }
@@ -132,7 +139,14 @@ class KeyboardInputView extends React.PureComponent<IKeyboardInputViewProps, IKe
     private _onKeyDown(evt: React.KeyboardEvent<HTMLInputElement>) {
         // 'Process' means hand-off to the IME -
         // so the composition events should handle this
-        if (evt.key === "Process" || evt.key === "Dead") {
+        if (evt.key === "Process" || this.state.isDead) {
+            return
+        }
+
+        if (evt.key === "Dead") {
+            this.setState({
+                isDead: true,
+            })
             return
         }
 
@@ -198,6 +212,7 @@ class KeyboardInputView extends React.PureComponent<IKeyboardInputViewProps, IKe
 
     private _commit(val: string): void {
         this.setState({
+            isDead: false,
             isComposing: false,
             compositionTextWidthInPixels: 0,
         })

--- a/browser/src/Editor/KeyboardInput.tsx
+++ b/browser/src/Editor/KeyboardInput.tsx
@@ -29,12 +29,6 @@ interface IKeyboardInputViewProps {
 }
 
 interface IKeyboardInputViewState {
-
-    /**
-     * Tracks if a dead key has been pressed, in which we should use the `input` strategy
-     */
-    isDead: boolean
-
     /**
      * Tracks if composition is occurring (ie, an IME is active)
      */
@@ -64,7 +58,6 @@ class KeyboardInputView extends React.PureComponent<IKeyboardInputViewProps, IKe
         super()
 
         this.state = {
-            isDead: false,
             isComposing: false,
             compositionTextWidthInPixels: 0,
         }
@@ -135,14 +128,7 @@ class KeyboardInputView extends React.PureComponent<IKeyboardInputViewProps, IKe
     private _onKeyDown(evt: React.KeyboardEvent<HTMLInputElement>) {
         // 'Process' means hand-off to the IME -
         // so the composition events should handle this
-        if (evt.key === "Process" || this.state.isDead) {
-            return
-        }
-
-        if (evt.key === "Dead") {
-            this.setState({
-                isDead: true,
-            })
+        if (evt.key === "Process" || evt.key === "Dead") {
             return
         }
 

--- a/browser/src/Editor/KeyboardInput.tsx
+++ b/browser/src/Editor/KeyboardInput.tsx
@@ -192,7 +192,6 @@ class KeyboardInputView extends React.PureComponent<IKeyboardInputViewProps, IKe
 
     private _commit(val: string): void {
         this.setState({
-            isDead: false,
             isComposing: false,
             compositionTextWidthInPixels: 0,
         })

--- a/browser/src/Editor/KeyboardInput.tsx
+++ b/browser/src/Editor/KeyboardInput.tsx
@@ -23,7 +23,6 @@ interface IKeyboardInputViewProps {
     height: number
     onKeyDown?: (key: string) => void
     foregroundColor: string
-    imeEnabled: boolean
     fontFamily: string
     fontSize: string
     fontCharacterWidthInPixels: number
@@ -119,15 +118,12 @@ class KeyboardInputView extends React.PureComponent<IKeyboardInputViewProps, IKe
             width: this.state.compositionTextWidthInPixels + "px",
         }
 
-        // IME is disabled for 'password' type fields
-        const inputType = this.props.imeEnabled ? "text" : "password"
-
         return <div style={containerStyle}>
             <div style={backgroundStyle} />
             <input
                 style={inputStyle}
                 ref={(elem) => this._keyboardElement = elem}
-                type={inputType}
+                type={"text"}
                 onKeyDown={(evt) => this._onKeyDown(evt)}
                 onCompositionEnd={(evt) => this._onCompositionEnd(evt)}
                 onCompositionUpdate={(evt) => this._onCompositionUpdate(evt)}
@@ -160,13 +156,11 @@ class KeyboardInputView extends React.PureComponent<IKeyboardInputViewProps, IKe
             return
         }
 
-        const imeDisabled = !this.props.imeEnabled
         const isMetaCommand = key.length > 1
 
-        // If ime is disabled, always pass the key event through...
-        // Otherwise, we'll let the `input` handler take care of it,
+        // We'll let the `input` handler take care of it,
         // unless it is a keystroke containing meta characters
-        if (imeDisabled || isMetaCommand) {
+        if (isMetaCommand) {
             this._commit(key)
             evt.preventDefault()
             return
@@ -229,7 +223,6 @@ const mapStateToProps = (state: IState, originalProps: IKeyboardInputProps): IKe
         left: state.cursorPixelX,
         height: state.fontPixelHeight,
         foregroundColor: state.foregroundColor,
-        imeEnabled: true,
         fontFamily: state.fontFamily,
         fontSize: state.fontSize,
         fontCharacterWidthInPixels: state.fontPixelWidth,

--- a/browser/src/Editor/KeyboardInput.tsx
+++ b/browser/src/Editor/KeyboardInput.tsx
@@ -82,15 +82,18 @@ class KeyboardInputView extends React.PureComponent<IKeyboardInputViewProps, IKe
             top: this.props.top.toString() + "px",
             left: this.props.left.toString() + "px",
             height: this.props.height.toString() + "px",
+            right: "0px",
             pointerEvents: "none",
             opacity,
-            width: "100%",
+            overflow: 'hidden',
         }
 
         const inputStyle: React.CSSProperties = {
             position: "absolute",
             padding: "0px",
-            width: "100%",
+            width: '100%',
+            left: "0px",
+            right: "0px",
             color: "black",
             border: "0px",
             outline: "none",
@@ -102,6 +105,7 @@ class KeyboardInputView extends React.PureComponent<IKeyboardInputViewProps, IKe
             position: "absolute",
             height: "100%",
             backgroundColor: "white",
+            left: "0px",
             padding: "2px",
             marginTop: "-2px",
             marginLeft: "-2px",

--- a/browser/src/Editor/KeyboardInput.tsx
+++ b/browser/src/Editor/KeyboardInput.tsx
@@ -229,7 +229,7 @@ const mapStateToProps = (state: IState, originalProps: IKeyboardInputProps): IKe
         left: state.cursorPixelX,
         height: state.fontPixelHeight,
         foregroundColor: state.foregroundColor,
-        imeEnabled: state.mode === "insert",
+        imeEnabled: true,
         fontFamily: state.fontFamily,
         fontSize: state.fontSize,
         fontCharacterWidthInPixels: state.fontPixelWidth,

--- a/browser/src/Editor/KeyboardInput.tsx
+++ b/browser/src/Editor/KeyboardInput.tsx
@@ -84,13 +84,13 @@ class KeyboardInputView extends React.PureComponent<IKeyboardInputViewProps, IKe
             right: "0px",
             pointerEvents: "none",
             opacity,
-            overflow: 'hidden',
+            overflow: "hidden",
         }
 
         const inputStyle: React.CSSProperties = {
             position: "absolute",
             padding: "0px",
-            width: '100%',
+            width: "100%",
             left: "0px",
             right: "0px",
             color: "black",

--- a/browser/src/Font.ts
+++ b/browser/src/Font.ts
@@ -25,7 +25,7 @@ export function measureFont(fontFamily: string, fontSize: string, characterToTes
     const rect = div.getBoundingClientRect()
 
     const width = rect.width
-    const height = Math.ceil(rect.height)
+    const height = rect.height
 
     document.body.removeChild(div)
 

--- a/browser/src/Font.ts
+++ b/browser/src/Font.ts
@@ -25,7 +25,7 @@ export function measureFont(fontFamily: string, fontSize: string, characterToTes
     const rect = div.getBoundingClientRect()
 
     const width = rect.width
-    const height = rect.height
+    const height = Math.ceil(rect.height)
 
     document.body.removeChild(div)
 

--- a/test/Manual.md
+++ b/test/Manual.md
@@ -3,6 +3,7 @@
 Ideally, these test cases could be automated to minimize overhead with the release process
 
 ## Internationalization
+
 - German:
     - [, ] (Alt5,6 on German OSX, Alt7/8 on Windows International)
     - {} (Alt 8,9 on German OSX, Alt 6,9 on Windows International)
@@ -15,4 +16,6 @@ Ideally, these test cases could be automated to minimize overhead with the relea
     - `a (`+a)
     - 'a ('+a)
     - ß (AltGr+S)
+    - Dead key in normal mode - navigate to mark (ma, `+space+a)
+    - Dead key on command line
 


### PR DESCRIPTION
Previously, we'd only enable the IME / composition when in insert mode. Looking at how other platforms behave (Iike vim with Hiragana on OSX), it seems the composition / IME is always enabled across modes.

This simplifies the logic, while addressing the issue with #746.

This also addresses a separate issue, where when typing near the far right edge of the screen, the entire app body would scroll - due to the input overflowing. This was addressed in 4ebe8d2.