### PR TITLE
Fix `ERR_FILE_NOT_FOUND` on startup with no background image

### DIFF
--- a/browser/src/Config.ts
+++ b/browser/src/Config.ts
@@ -150,7 +150,7 @@ export class Config {
 
         "editor.backgroundOpacity": 1.0,
         "editor.backgroundImageUrl": null,
-        "editor.backgroundImageSize": "initial",
+        "editor.backgroundImageSize": "cover",
 
         "editor.clipboard.enabled": true,
 

--- a/browser/src/UI/components/Background.tsx
+++ b/browser/src/UI/components/Background.tsx
@@ -18,9 +18,9 @@ export class BackgroundView extends React.PureComponent<IBackgroundProps, void> 
         }
 
         return <div>
-                <BackgroundImageView {...this.props} />
-                 <div className="background-cover" style={coverStyle}></div>
-               </div>
+            <BackgroundImageView {...this.props} />
+            <div className="background-cover" style={coverStyle}></div>
+        </div>
     }
 }
 
@@ -31,7 +31,8 @@ export const BackgroundImageView = (props: IBackgroundProps) => {
             backgroundImage: "url(" + props.backgroundImageUrl + ")",
             backgroundSize: props.backgroundImageSize || "cover",
         }
-         return <div className="background-image" style={imageStyle}></div>
+
+        return <div className="background-image" style={imageStyle}></div>
     } else {
         return null
     }

--- a/browser/src/UI/components/Background.tsx
+++ b/browser/src/UI/components/Background.tsx
@@ -10,21 +10,30 @@ export interface IBackgroundProps {
     backgroundOpacity: number
 }
 
-export class BackgroundRenderer extends React.PureComponent<IBackgroundProps, void> {
+export class BackgroundView extends React.PureComponent<IBackgroundProps, void> {
     public render(): JSX.Element {
-        const imageStyle = {
-            backgroundImage: "url(" + this.props.backgroundImageUrl + ")",
-            backgroundSize: this.props.backgroundImageSize || "cover",
-        }
         const coverStyle = {
             backgroundColor: this.props.backgroundColor,
             opacity: this.props.backgroundOpacity,
         }
 
         return <div>
-                 <div className="background-image" style={imageStyle}></div>
+                <BackgroundImageView {...this.props} />
                  <div className="background-cover" style={coverStyle}></div>
                </div>
+    }
+}
+
+export const BackgroundImageView = (props: IBackgroundProps) => {
+
+    if (props.backgroundImageUrl) {
+        const imageStyle = {
+            backgroundImage: "url(" + props.backgroundImageUrl + ")",
+            backgroundSize: props.backgroundImageSize || "cover",
+        }
+         return <div className="background-image" style={imageStyle}></div>
+    } else {
+        return null
     }
 }
 
@@ -38,4 +47,4 @@ const mapStateToProps = (state: State.IState): IBackgroundProps => {
     }
 }
 
-export const Background = connect(mapStateToProps)(BackgroundRenderer)
+export const Background = connect(mapStateToProps)(BackgroundView)


### PR DESCRIPTION
__Issue:__ There is a console error on startup when a background image isn't specified - this is because we still create a `div` with `background-image` set to null. This causes problems during debugging because it can get mistaken for an actual error, so fixing it will reduce noise.

__Fix:__ Only render the element with `background-image` if a background is actually specified.