### PR TITLE
Fix #504 - Part 1: Split out `activeEditor` and `allEditors` API, add bufferEnter/Leave events

### DIFF
--- a/browser/src/Editor/NeovimEditor.tsx
+++ b/browser/src/Editor/NeovimEditor.tsx
@@ -330,6 +330,12 @@ export class NeovimEditor implements IEditor {
         tasks.onEvent(evt)
 
         if (eventName === "BufEnter") {
+
+            this._onBufferEnterEvent.dispatch({
+                filePath: evt.bufferFullPath,
+                language: evt.filetype,
+            })
+
             // TODO: More convenient way to hide all UI?
             UI.Actions.hideCompletions()
             UI.Actions.hidePopupMenu()
@@ -337,6 +343,11 @@ export class NeovimEditor implements IEditor {
             UI.Actions.hideQuickInfo()
 
             UI.Actions.bufferEnter(evt.bufferNumber, evt.bufferFullPath, evt.bufferTotalLines, evt.hidden, evt.listed)
+        } else if (eventName === "BufLeave") {
+            this._onBufferLeaveEvent.dispatch({
+                fileType: evt.bufferFullPath,
+                language: evt.filetype,
+            })
         } else if (eventName === "BufWritePost") {
             // After we save we aren't modified... but we can pass it in just to be safe
             UI.Actions.bufferSave(evt.bufferNumber, evt.modified, evt.version)

--- a/browser/src/Editor/NeovimEditor.tsx
+++ b/browser/src/Editor/NeovimEditor.tsx
@@ -345,7 +345,7 @@ export class NeovimEditor implements IEditor {
             UI.Actions.bufferEnter(evt.bufferNumber, evt.bufferFullPath, evt.bufferTotalLines, evt.hidden, evt.listed)
         } else if (eventName === "BufLeave") {
             this._onBufferLeaveEvent.dispatch({
-                fileType: evt.bufferFullPath,
+                filePath: evt.bufferFullPath,
                 language: evt.filetype,
             })
         } else if (eventName === "BufWritePost") {

--- a/browser/src/Editor/NeovimEditor.tsx
+++ b/browser/src/Editor/NeovimEditor.tsx
@@ -55,7 +55,10 @@ export class NeovimEditor implements IEditor {
     private _element: HTMLElement
 
     private _currentMode: string
-    private _onModeChangedEvent: Event<string> = new Event<string>()
+    private _onModeChangedEvent = new Event<string>()
+    private _onBufferEnterEvent = new Event<Oni.EditorBufferEventArgs>()
+    private _onBufferLeaveEvent = new Event<Oni.EditorBufferEventArgs>()
+
     private _hasLoaded: boolean = false
 
     // Overlays
@@ -69,6 +72,14 @@ export class NeovimEditor implements IEditor {
 
     public get onModeChanged(): IEvent<string> {
         return this._onModeChangedEvent
+    }
+
+    public get onBufferEnter(): IEvent<Oni.EditorBufferEventArgs> {
+        return this._onBufferEnterEvent
+    }
+
+    public get onBufferLeave(): IEvent<Oni.EditorBufferEventArgs> {
+        return this._onBufferLeaveEvent
     }
 
     // Capabilities

--- a/browser/src/Services/EditorManager.ts
+++ b/browser/src/Services/EditorManager.ts
@@ -52,11 +52,13 @@ export class EditorManager implements Oni.EditorManager {
  * This enables consumers to use `Oni.editor.allEditors.onModeChanged((newMode) => { ... }),
  * for convenience, as it handles manages tracking subscriptions as the active editor changes.
  */
-export class AllEditors implements Oni.Editor {
+class AllEditors implements Oni.Editor {
     private _activeEditor: Oni.Editor
-    private _onModeChanged: Event<string> = new Event<string>()
     private _subscriptions: IDisposable[] = []
 
+    private _onModeChanged = new Event<string>()
+    private _onBufferEnter = new Event<Oni.EditorBufferEventArgs>()
+    private _onBufferLeave = new Event<Oni.EditorBufferEventArgs>()
     /**
      * API Methods
      */
@@ -80,6 +82,14 @@ export class AllEditors implements Oni.Editor {
         return this._onModeChanged
     }
 
+    public get onBufferEnter(): IEvent<Oni.EditorBufferEventArgs> {
+        return this._onBufferEnter
+    }
+
+    public get onBufferLeave(): IEvent<Oni.EditorBufferEventArgs> {
+        return this._onBufferLeave
+    }
+
     /**
      * Internal methods
      */
@@ -89,6 +99,8 @@ export class AllEditors implements Oni.Editor {
         this._subscriptions.forEach((d) => d.dispose())
         this._subscriptions = []
         this._subscriptions.push(newEditor.onModeChanged.subscribe((val) => this._onModeChanged.dispatch(val)))
+        this._subscriptions.push(newEditor.onBufferEnter.subscribe((val) => this._onBufferEnter.dispatch(val)))
+        this._subscriptions.push(newEditor.onBufferLeave.subscribe((val) => this._onBufferLeave.dispatch(val)))
     }
 
     public getUnderlyingEditor(): Oni.Editor {

--- a/browser/src/Services/EditorManager.ts
+++ b/browser/src/Services/EditorManager.ts
@@ -12,12 +12,17 @@ import { Event, IEvent } from "./../Event"
 import { IDisposable } from "./../IDisposable"
 
 export class EditorManager implements Oni.EditorManager {
-    private _activeEditor: ActiveEditor = new ActiveEditor()
+    private _activeEditor: Oni.Editor = null
+    private _allEditors: AllEditors = new AllEditors()
     private _onActiveEditorChanged: Event<Oni.Editor> = new Event<Oni.Editor>()
 
     /**
      * API Methods
      */
+    public get allEditors(): Oni.Editor {
+        return this._allEditors
+    }
+
     public get activeEditor(): Oni.Editor {
         return this._activeEditor
     }
@@ -30,21 +35,24 @@ export class EditorManager implements Oni.EditorManager {
      * Internal Methods
      */
     public setActiveEditor(editor: Oni.Editor) {
-        const oldEditor = this._activeEditor.getUnderlyingEditor()
+        this._activeEditor = editor
+
+        const oldEditor = this._allEditors.getUnderlyingEditor()
         if (editor !== oldEditor) {
             this._onActiveEditorChanged.dispatch(editor)
-            this._activeEditor.setActiveEditor(editor)
+            this._allEditors.setActiveEditor(editor)
         }
     }
 }
 
 /**
- * ActiveEditor is a proxy for the Neovim interface,
- * exposing methods of the current editor.
+ * AllEditors is a proxy for the Neovim interface,
+ * exposing methods of 'all' editors, as an aggregate.
  *
- * This manages tracking subscriptions as the active editor changes.
+ * This enables consumers to use `Oni.editor.allEditors.onModeChanged((newMode) => { ... }),
+ * for convenience, as it handles manages tracking subscriptions as the active editor changes.
  */
-export class ActiveEditor implements Oni.Editor {
+export class AllEditors implements Oni.Editor {
     private _activeEditor: Oni.Editor
     private _onModeChanged: Event<string> = new Event<string>()
     private _subscriptions: IDisposable[] = []

--- a/definitions/Oni.d.ts
+++ b/definitions/Oni.d.ts
@@ -49,7 +49,7 @@ declare namespace Oni {
 
     export interface EditorBufferEventArgs {
         filePath: string
-        languageType: string
+        language: string
     }
 
     export interface Editor {

--- a/definitions/Oni.d.ts
+++ b/definitions/Oni.d.ts
@@ -26,6 +26,7 @@ declare namespace Oni {
     }
 
     export interface EditorManager {
+        allEditors: Editor
         activeEditor: Editor
     }
 
@@ -46,9 +47,17 @@ declare namespace Oni {
         command(command: string): Promise<void>
     }
 
+    export interface EditorBufferEventArgs {
+        filePath: string
+        languageType: string
+    }
+
     export interface Editor {
         mode: string
         onModeChanged: IEvent<string>
+
+        onBufferEnter: IEvent<EditorBufferEventArgs>
+        onBufferLeave: IEvent<EditorBufferEventArgs>
 
         // Optional capabilities for the editor to implement
         neovim?: NeovimEditorCapability


### PR DESCRIPTION
This is preparatory API work for the larger refactor, cleaning up the language service integration.