### PR TITLE
[WIP] Support `clangd` as an LSP client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,7 @@ yarn.lock
 $LOCALAPPDATA
 
 # Output
-lib
+/lib
 lib_test
 dist
 

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@ yarn.lock
 # Grunt intermediate storage (http://gruntjs.com/creating-plugins#storing-task-files)
 .grunt
 
+# Python
+.mypy_cache
+
 # Local app data
 $LOCALAPPDATA
 

--- a/browser/src/Plugins/Api/LanguageClient/LanguageClient.ts
+++ b/browser/src/Plugins/Api/LanguageClient/LanguageClient.ts
@@ -193,7 +193,7 @@ export class LanguageClient {
             Log.error(`[LANGUAGE CLIENT - ERROR]: ${msg}`)
             this._statusBar.setStatus(LanguageClientState.Error)
         }
-        this._process.stderr.on("data", (this._startOptions.stderrAsLog || true) ? logFunc : errFunc)
+        this._process.stderr.on("data", (this._startOptions.stderrAsLog) ? logFunc : errFunc)
 
         this._connection = rpc.createMessageConnection(
             (new rpc.StreamMessageReader(this._process.stdout)) as any,

--- a/browser/src/Plugins/Api/LanguageClient/LanguageClient.ts
+++ b/browser/src/Plugins/Api/LanguageClient/LanguageClient.ts
@@ -37,11 +37,16 @@ export interface ServerRunOptions {
     module?: string
 
     /**
-     * Arguments to pass to the language servicew
+     * Arguments to pass to the language service
      */
     args?: string[]
 
     // TODO: TransportKind option?
+
+    /**
+     * Indicates whether stderr of the LSP server is used for logs or actual errors
+     */
+    stderrAsLog?: boolean
 }
 
 /**
@@ -181,10 +186,14 @@ export class LanguageClient {
             Log.warn(`[LANGUAGE CLIENT]: Process closed with exit code ${code} and signal ${signal}`)
         })
 
-        this._process.stderr.on("data", (msg) => {
+        const logFunc = (msg: any) => {
+            Log.debug(`[LANGUAGE CLIENT - DEBUG] ${msg}`)
+        }
+        const errFunc = (msg: any) => {
             Log.error(`[LANGUAGE CLIENT - ERROR]: ${msg}`)
             this._statusBar.setStatus(LanguageClientState.Error)
-        })
+        }
+        this._process.stderr.on("data", (this._startOptions.stderrAsLog || true) ? logFunc : errFunc)
 
         this._connection = rpc.createMessageConnection(
             (new rpc.StreamMessageReader(this._process.stdout)) as any,

--- a/browser/src/Plugins/Api/LanguageClient/LanguageClient.ts
+++ b/browser/src/Plugins/Api/LanguageClient/LanguageClient.ts
@@ -375,6 +375,7 @@ export class LanguageClient {
             detail: i.detail,
             documentation: this._getCompletionDocumentation(i),
             kind: i.kind,
+            insertText: i.insertText,
         }))
 
         return {

--- a/browser/src/UI/Selectors.ts
+++ b/browser/src/UI/Selectors.ts
@@ -35,7 +35,12 @@ export const areCompletionsVisible = (state: State.IState) => {
 
 export const getSelectedCompletion = (state: State.IState) => {
     const autoCompletion = state.autoCompletion
-    return autoCompletion ? autoCompletion.entries[autoCompletion.selectedIndex].label : null
+    if (!autoCompletion) {
+        return null
+    }
+
+    const completion = autoCompletion.entries[autoCompletion.selectedIndex]
+    return completion.insertText ? completion.insertText : completion.label
 }
 
 export const getAllBuffers = (buffers: State.IBufferState): State.IBuffer[] => {

--- a/definitions/Oni.d.ts
+++ b/definitions/Oni.d.ts
@@ -234,6 +234,7 @@ declare namespace Oni {
             label: string
             detail?: string
             documentation?: string
+            insertText?: string
         }
 
         export interface EvaluationResult {

--- a/vim/core/oni-plugin-cpp/README.md
+++ b/vim/core/oni-plugin-cpp/README.md
@@ -1,0 +1,16 @@
+# oni-language-cpp
+
+## C++ Language Plugin for [Oni](https://github.com/extr0py/oni)
+
+C++ support for Oni uses the [clangd](https://clang.llvm.org/extra/clangd.html) which provides language capabilities for C and C++.
+
+## Usage
+
+To get started:
+
+- Get a working `clangd` (both code and executables are available [here](http://releases.llvm.org/download.html))
+- Make sure that `clangd` is available globally (for instance, by adding it to an environment variable)
+
+## Known Issues
+
+None yet

--- a/vim/core/oni-plugin-cpp/lib/index.js
+++ b/vim/core/oni-plugin-cpp/lib/index.js
@@ -8,6 +8,7 @@ const activate = (Oni) => {
 
     const serverOptions = {
         command,
+        stderrAsLog: true,
     }
 
     const getInitializationOptionsAsync = (filePath) => {
@@ -19,7 +20,6 @@ const activate = (Oni) => {
     }
 
     const client = Oni.createLanguageClient(serverOptions, getInitializationOptionsAsync)
-    const stderrAsLog = true
 }
 
 module.exports = {

--- a/vim/core/oni-plugin-cpp/lib/index.js
+++ b/vim/core/oni-plugin-cpp/lib/index.js
@@ -1,0 +1,27 @@
+const fs = require("fs")
+const path = require("path")
+const childProcess = require("child_process")
+
+const activate = (Oni) => {
+
+    const command = Oni.configuration.getValue("cpp.langServerCommand", "clangd")
+
+    const serverOptions = {
+        command,
+    }
+
+    const getInitializationOptionsAsync = (filePath) => {
+        return Promise.resolve({
+            clientName: "cpp",
+            disableDocumentSymbol: false,
+            rootPath: "file:///" + filePath,
+        })
+    }
+
+    const client = Oni.createLanguageClient(serverOptions, getInitializationOptionsAsync)
+    const stderrAsLog = true
+}
+
+module.exports = {
+    activate,
+}

--- a/vim/core/oni-plugin-cpp/package.json
+++ b/vim/core/oni-plugin-cpp/package.json
@@ -1,0 +1,18 @@
+{
+    "name": "oni-plugin-cpp",
+    "version": "0.0.1",
+    "main": "lib/index.js",
+    "engines": {
+        "oni": "^0.2.2"
+    },
+    "oni": {
+        "supportedFileTypes": [
+            "cpp",
+            "c"
+        ]
+    },
+    "dependencies": {
+    },
+    "devDependencies": {
+    }
+}


### PR DESCRIPTION
This is still a work in progress.

`clangd` works with the changes in this PR.
However, there are some issues:

# Completion completes too much (probably `clangd`-s fault)

For instance, when writing `namesp`, the first completion option is `namespace name`.
The `name` part is a place holder for the name of the namespace.
The issue here, is that selecting that option for completion adds the word `name`.
I suspect that this is due to a misuse of the `label` LSP field on the server side.

# Stdout used for debugging

`clangd` outputs a copy of the input and output as logs into stdout.
The format is more or less `HTTP-HEADER <-- request-msg reply-msg -->`.
As a temporary hack, a new flag is introduced that instructs which behavior should be used with the stderr of the specific LSP server (either log it as error or as debug).

Which brings me the the next issue: IDK TypeScript, so there is a run-time error with this flag.
It is always evaluated as undefined so I or'ed it with `true` until I figure out what's wrong (hints will be appreciated).