### PR TITLE
Refactoring: Remove `redux-action` and channel dependency for StatusBar

### DIFF
--- a/browser/src/Plugins/Api/Oni.ts
+++ b/browser/src/Plugins/Api/Oni.ts
@@ -102,7 +102,7 @@ export class Oni extends EventEmitter implements Oni.Plugin.Api {
         this._diagnostics = new Diagnostics(this._channel)
         this._dependencies = new Dependencies()
         this._commands = new Commands(this._channel)
-        this._statusBar = new StatusBar(this._channel)
+        this._statusBar = new StatusBar()
         this._ui = new Ui(react)
         this._services = new Services()
         this._process = new Process()

--- a/browser/src/Plugins/Api/Oni.ts
+++ b/browser/src/Plugins/Api/Oni.ts
@@ -5,7 +5,6 @@ import { IPluginChannel } from "./Channel"
 
 import { Commands } from "./Commands"
 import { Diagnostics } from "./Diagnostics"
-import { StatusBar } from "./StatusBar"
 
 import { DebouncedLanguageService } from "./DebouncedLanguageService"
 import { InitializationParamsCreator, LanguageClient, ServerRunOptions } from "./LanguageClient/LanguageClient"
@@ -16,6 +15,7 @@ import { Ui } from "./Ui"
 
 import { editorManager } from "./../../Services/EditorManager"
 import { inputManager } from "./../../Services/InputManager"
+import { statusBar } from "./../../Services/StatusBar"
 
 import * as Config from "./../../Config"
 import * as Log from "./../../Log"
@@ -40,7 +40,6 @@ const helpers = {
 export class Oni extends EventEmitter implements Oni.Plugin.Api {
 
     private _dependencies: Dependencies
-    private _statusBar: StatusBar
     private _commands: Commands
     private _languageService: Oni.Plugin.LanguageService
     private _diagnostics: Oni.Plugin.Diagnostics.Api
@@ -80,8 +79,8 @@ export class Oni extends EventEmitter implements Oni.Plugin.Api {
         return this._process
     }
 
-    public get statusBar(): StatusBar {
-        return this._statusBar
+    public get statusBar(): Oni.StatusBar {
+        return statusBar
     }
 
     public get ui(): Ui {
@@ -102,7 +101,6 @@ export class Oni extends EventEmitter implements Oni.Plugin.Api {
         this._diagnostics = new Diagnostics(this._channel)
         this._dependencies = new Dependencies()
         this._commands = new Commands(this._channel)
-        this._statusBar = new StatusBar()
         this._ui = new Ui(react)
         this._services = new Services()
         this._process = new Process()

--- a/browser/src/Plugins/Api/StatusBar.ts
+++ b/browser/src/Plugins/Api/StatusBar.ts
@@ -6,7 +6,7 @@
 
 import { IPluginChannel } from "./Channel"
 
-import * as ActionCreators from "./../../UI/ActionCreators"
+import * as UI from "./../../UI"
 
 export enum StatusBarAlignment {
     Left,
@@ -24,7 +24,6 @@ export class StatusBarItem implements Oni.StatusBarItem {
     private _visible: boolean = false
 
     constructor(
-        private _channel: IPluginChannel,
         private _id: string,
         private _alignment?: StatusBarAlignment | null,
         private _priority?: number | null,
@@ -32,12 +31,12 @@ export class StatusBarItem implements Oni.StatusBarItem {
 
     public show(): void {
         this._visible = true
-        this._channel.send("redux-action", null, ActionCreators.showStatusBarItem(this._id, this._contents, this._alignment, this._priority))
+        UI.Actions.showStatusBarItem(this._id, this._contents, this._alignment, this._priority)
     }
 
     public hide(): void {
         this._visible = false
-        this._channel.send("redux-action", null, ActionCreators.hideStatusBarItem(this._id))
+        UI.Actions.hideStatusBarItem(this._id)
     }
 
     public setContents(element: any): void {
@@ -56,12 +55,8 @@ export class StatusBarItem implements Oni.StatusBarItem {
 export class StatusBar implements Oni.StatusBar {
     private _id: number = 0
 
-    constructor(
-        private _channel: IPluginChannel,
-    ) { }
-
     public getItem(globalId: string): Oni.StatusBarItem {
-        return new StatusBarItem(this._channel, globalId)
+        return new StatusBarItem(globalId)
     }
 
     public createItem(alignment: StatusBarAlignment, priority: number = 0, globalId?: string): Oni.StatusBarItem {
@@ -69,6 +64,6 @@ export class StatusBar implements Oni.StatusBar {
 
         const statusBarId = globalId || `${this._channel.metadata.name}${this._id.toString()}`
 
-        return new StatusBarItem(this._channel, statusBarId, alignment, priority)
+        return new StatusBarItem(statusBarId, alignment, priority)
     }
 }

--- a/browser/src/Plugins/PluginManager.ts
+++ b/browser/src/Plugins/PluginManager.ts
@@ -232,9 +232,6 @@ export class PluginManager extends EventEmitter {
             case "signature-help-response":
                 this.emit("signature-help-response", pluginResponse.error, pluginResponse.payload)
                 break
-            case "redux-action":
-                UI.store.dispatch(pluginResponse.payload)
-                break
             default:
                 this.emit("logWarning", "Unexpected plugin type: " + pluginResponse.type)
         }

--- a/browser/src/Services/StatusBar.ts
+++ b/browser/src/Services/StatusBar.ts
@@ -4,7 +4,7 @@
  * Implements API surface area for working with the status bar
  */
 
-import * as UI from "./../../UI"
+import * as UI from "./../UI"
 
 export enum StatusBarAlignment {
     Left,
@@ -50,7 +50,7 @@ export class StatusBarItem implements Oni.StatusBarItem {
     }
 }
 
-export class StatusBar implements Oni.StatusBar {
+class StatusBar implements Oni.StatusBar {
     private _id: number = 0
 
     public getItem(globalId: string): Oni.StatusBarItem {
@@ -65,3 +65,5 @@ export class StatusBar implements Oni.StatusBar {
         return new StatusBarItem(statusBarId, alignment, priority)
     }
 }
+
+export const statusBar = new StatusBar()

--- a/browser/src/Services/StatusBar.ts
+++ b/browser/src/Services/StatusBar.ts
@@ -4,8 +4,6 @@
  * Implements API surface area for working with the status bar
  */
 
-import { IPluginChannel } from "./Channel"
-
 import * as UI from "./../../UI"
 
 export enum StatusBarAlignment {
@@ -62,7 +60,7 @@ export class StatusBar implements Oni.StatusBar {
     public createItem(alignment: StatusBarAlignment, priority: number = 0, globalId?: string): Oni.StatusBarItem {
         this._id++
 
-        const statusBarId = globalId || `${this._channel.metadata.name}${this._id.toString()}`
+        const statusBarId = globalId || `${this._id.toString()}`
 
         return new StatusBarItem(statusBarId, alignment, priority)
     }


### PR DESCRIPTION
This is a small refactoring to remove the `channel` and `redux-action` from the StatusBar API (and move it to a service, to be in-line with some of the other services).

The vision for the API is that, the API surface we expose is essentially the same as the internals of Oni, making it easy to test the API and also ensure that the API surface is able to power interesting scenarios. This is a small incremental step, but I'd like to continue pruning down the `PluginManager` and `Channel` surface areas...