### PR TITLE
Fix #483 - Bind `<m-q>` to quit Oni by default on Mac

### DIFF
--- a/browser/src/Input/KeyBindings.ts
+++ b/browser/src/Input/KeyBindings.ts
@@ -17,15 +17,17 @@ export const applyDefaultKeyBindings = (oni: Oni.Plugin.Api, config: Configurati
     const isNormalMode = () => editors.activeEditor.mode === "normal"
     const isInsertOrCommandMode = () => editors.activeEditor.mode === "insert" || editors.activeEditor.mode === "cmdline_normal"
 
-    if (Platform.isLinux() || Platform.isWindows()) {
-        if (config.getValue("editor.clipboard.enabled")) {
-            input.bind("<C-c>", "editor.clipboard.yank", isVisualMode)
-            input.bind("<C-v>", "editor.clipboard.paste", isInsertOrCommandMode)
-        }
-    } else {
+    if (Platform.isMac()) {
+        input.bind("<M-q>", "oni.quit")
+
         if (config.getValue("editor.clipboard.enabled")) {
             input.bind("<M-c>", "editor.clipboard.yank", isVisualMode)
             input.bind("<M-v>", "editor.clipboard.paste", isInsertOrCommandMode)
+        }
+    } else {
+        if (config.getValue("editor.clipboard.enabled")) {
+            input.bind("<C-c>", "editor.clipboard.yank", isVisualMode)
+            input.bind("<C-v>", "editor.clipboard.paste", isInsertOrCommandMode)
         }
     }
 

--- a/browser/src/Services/Commands.ts
+++ b/browser/src/Services/Commands.ts
@@ -38,6 +38,8 @@ export const registerBuiltInCommands = (commandManager: CommandManager, pluginMa
         new CallbackCommand("editor.clipboard.paste", "Clipboard: Paste", "Paste clipboard contents into active text", () => pasteContents(neovimInstance)),
         new CallbackCommand("editor.clipboard.yank", "Clipboard: Yank", "Yank contents to clipboard", () => neovimInstance.input("y")),
 
+        new CallbackCommand("oni.quit", null, null, () => remote.getCurrentWindow().close()),
+
         // Debug
         new CallbackCommand("oni.debug.openDevTools", "Open DevTools", "Debug Oni and any running plugins using the Chrome developer tools", () => remote.getCurrentWindow().webContents.openDevTools()),
         new CallbackCommand("oni.debug.reload", "Reload Oni", "Reloads the Oni instance. You will lose all unsaved changes", () => remote.getCurrentWindow().reload()),


### PR DESCRIPTION
Fix #483 - `<Cmd+q>` should quit on Mac. This is the behavior for OS X apps in general, there's no reason Oni should be different