### PR TITLE
Add option to maximize Oni on startup.

### DIFF
--- a/browser/src/Services/Configuration/DefaultConfiguration.ts
+++ b/browser/src/Services/Configuration/DefaultConfiguration.ts
@@ -57,6 +57,7 @@ const BaseConfiguration: IConfigurationValues = {
     "editor.scrollBar.visible": true,
 
     "editor.fullScreenOnStart": false,
+    "editor.maximizeScreenOnStart": false,
 
     "editor.cursorLine": true,
     "editor.cursorLineOpacity": 0.1,

--- a/browser/src/Services/Configuration/IConfigurationValues.ts
+++ b/browser/src/Services/Configuration/IConfigurationValues.ts
@@ -101,6 +101,7 @@ export interface IConfigurationValues {
     "editor.quickOpen.execCommand": string | null
 
     "editor.fullScreenOnStart": boolean
+    "editor.maximizeScreenOnStart": boolean
 
     "editor.cursorLine": boolean
     "editor.cursorLineOpacity": number

--- a/browser/src/index.tsx
+++ b/browser/src/index.tsx
@@ -21,6 +21,7 @@ const start = (args: string[]) => {
     const parsedArgs = minimist(args)
 
     let loadInitVim: boolean = false
+    let maximizeScreenOnStart: boolean = false
 
     // Helper for debugging:
     window["UI"] = UI // tslint:disable-line no-string-literal
@@ -54,6 +55,11 @@ const start = (args: string[]) => {
             ipcRenderer.send("rebuild-menu", loadInit)
             // don't rebuild menu unless oni.loadInitVim actually changed
             loadInitVim = loadInit
+        }
+
+        const maximizeScreen: boolean = configuration.getValue("editor.maximizeScreenOnStart")
+        if (maximizeScreen !== maximizeScreenOnStart) {
+            browserWindow.maximize()
         }
 
         browserWindow.setFullScreen(configuration.getValue("editor.fullScreenOnStart"))


### PR DESCRIPTION
The current `editor.fullScreenOnStart` is useful, but other times I just want Oni maximised, rather than fullscreen, so I've added an option for that.

Simple change so shouldn't need much changing, I'm just interested in how it should interact with `editor.fullScreenOnStart`.

Maximising then going full-screen is a valid operation, whereas going full-screen and then maximising the window will have no effect. So I've put full-screen second for now, and as such it will override maximising the screen.

In reality, you'd probably want some mechanism in the config file to warn you that you have both?