### PR TITLE
Fix whitescreen on opening command palette

### DIFF
--- a/browser/src/UI/components/HighlightText.tsx
+++ b/browser/src/UI/components/HighlightText.tsx
@@ -43,8 +43,9 @@ export class HighlightTextByIndex extends React.PureComponent<IHighlightTextByIn
 
         const childNodes: JSX.Element[] = []
         const highlightIndices = this.props.highlightIndices || []
+        const text = this.props.text || ""
 
-        this.props.text.split("").forEach((c: string, idx: number) => {
+        text.split("").forEach((c: string, idx: number) => {
 
             if (shouldHighlightIndex(idx, highlightIndices)) {
                 childNodes.push(<span className={this.props.highlightClassName}>{c}</span>)


### PR DESCRIPTION
__Issue:__ Due to some changes to the rendering workflow (by upgrading to React 16), there is a case where the `HighlightedTextByIndex` is rendered with an empty state. This causes a crash, because `this.props.text` is expected to be populated.

Since there is no error boundary with React, this bubbles up to the top-level, and causes a white-screen.

__Fix:__ This is a quick-fix to address the error and enable the command palette again, but longer-term there should be appropriate error boundaries set up.