### PR TITLE
Fix #473: Open binaries crashes Oni

### DIFF
--- a/browser/src/Services/BufferUpdates.ts
+++ b/browser/src/Services/BufferUpdates.ts
@@ -5,7 +5,7 @@
  * to the plugins. Sanitizes and manages incrementental state.
  */
 
-import { IIncrementalBufferUpdateEvent, IFullBufferUpdateEvent, INeovimInstance } from "./../neovim"
+import { IFullBufferUpdateEvent, IIncrementalBufferUpdateEvent, INeovimInstance } from "./../neovim"
 import { PluginManager } from "./../Plugins/PluginManager"
 
 export class BufferUpdates {

--- a/browser/src/Services/BufferUpdates.ts
+++ b/browser/src/Services/BufferUpdates.ts
@@ -5,7 +5,7 @@
  * to the plugins. Sanitizes and manages incrementental state.
  */
 
-import { INeovimInstance } from "./../neovim"
+import { IIncrementalBufferUpdateEvent, IFullBufferUpdateEvent, INeovimInstance } from "./../neovim"
 import { PluginManager } from "./../Plugins/PluginManager"
 
 export class BufferUpdates {
@@ -43,29 +43,30 @@ export class BufferUpdates {
             this._canSendIncrementalUpdates = (mode === "insert")
         })
 
-        this._neovimInstance.on("buffer-update", (args: Oni.EventContext, bufferLines: string[]) => {
-            const lastLine = args.line
-            this._lastArgs = args
-            this._lastBufferLines = bufferLines
-            this._modified = args.modified
-            this._lastBufferVersion = args.version
+        this._neovimInstance.onBufferUpdate.subscribe((args: IFullBufferUpdateEvent) => {
+            const lastLine = args.context.line
+            this._lastArgs = args.context
+            this._lastBufferLines = args.bufferLines
+            this._modified = args.context.modified
+            this._lastBufferVersion = args.context.version
 
             // If we can send incremental updates, and the line hasn't changed, just send the incremental change
-            if (this._canSendIncrementalUpdates && lastLine === args.line) {
-                const changedLine = bufferLines[args.line - 1]
-                // this._pluginManager.notifyBufferUpdateIncremental(args, args.line, changedLine)
+            if (this._canSendIncrementalUpdates && lastLine === args.context.line) {
+                const changedLine = args.bufferLines[args.context.line - 1]
+                this._pluginManager.notifyBufferUpdateIncremental(args.context, args.context.line, changedLine)
             } else {
-                // this._pluginManager.notifyBufferUpdate(args, bufferLines)
+                this._pluginManager.notifyBufferUpdate(args.context, args.bufferLines)
             }
         })
 
-        this._neovimInstance.on("buffer-update-incremental", (args: Oni.EventContext, bufferLine: string, lineNumber: number) => {
-            this._lastArgs = args
-            this._lastBufferLines[lineNumber - 1] = bufferLine
-            this._modified = args.modified
-            this._lastBufferVersion = args.version
+        this._neovimInstance.onBufferUpdateIncremental.subscribe((args: IIncrementalBufferUpdateEvent) => {
+            const { context, lineNumber, lineContents } = args
+            this._lastArgs = context
+            this._lastBufferLines[lineNumber - 1] = lineContents
+            this._modified = context.modified
+            this._lastBufferVersion = context.version
 
-            // this._pluginManager.notifyBufferUpdateIncremental(args, lineNumber, bufferLine)
+            this._pluginManager.notifyBufferUpdateIncremental(context, lineNumber, lineContents)
         })
     }
 }

--- a/browser/src/Services/BufferUpdates.ts
+++ b/browser/src/Services/BufferUpdates.ts
@@ -53,9 +53,9 @@ export class BufferUpdates {
             // If we can send incremental updates, and the line hasn't changed, just send the incremental change
             if (this._canSendIncrementalUpdates && lastLine === args.line) {
                 const changedLine = bufferLines[args.line - 1]
-                this._pluginManager.notifyBufferUpdateIncremental(args, args.line, changedLine)
+                // this._pluginManager.notifyBufferUpdateIncremental(args, args.line, changedLine)
             } else {
-                this._pluginManager.notifyBufferUpdate(args, bufferLines)
+                // this._pluginManager.notifyBufferUpdate(args, bufferLines)
             }
         })
 
@@ -65,7 +65,7 @@ export class BufferUpdates {
             this._modified = args.modified
             this._lastBufferVersion = args.version
 
-            this._pluginManager.notifyBufferUpdateIncremental(args, lineNumber, bufferLine)
+            // this._pluginManager.notifyBufferUpdateIncremental(args, lineNumber, bufferLine)
         })
     }
 }

--- a/browser/src/neovim/NeovimInstance.ts
+++ b/browser/src/neovim/NeovimInstance.ts
@@ -256,7 +256,7 @@ export class NeovimInstance extends EventEmitter implements INeovimInstance {
                 // Workaround for bug in neovim/node-client
                 // The 'uiAttach' method overrides the new 'nvim_ui_attach' method
                 return this._attachUI(size.cols, size.rows)
-                    .then(() => {
+                    .then(async () => {
                         Log.info("Attach success")
 
                         performance.mark("NeovimInstance.Plugins.Start")
@@ -266,8 +266,8 @@ export class NeovimInstance extends EventEmitter implements INeovimInstance {
                         configuration.activate(api)
 
                         // set title after attaching listeners so we can get the initial title
-                        this.command("set title")
-                        this.callFunction("OniConnect", [])
+                        await this.command("set title")
+                        await this.callFunction("OniConnect", [])
                     },
                     (err: any) => {
                         this.emit("error", err)
@@ -502,8 +502,9 @@ export class NeovimInstance extends EventEmitter implements INeovimInstance {
 
         const buffer = new Buffer(context.bufferNumber as any, this._neovim)
 
-        if (endRange > 10000)
+        if (endRange > 10000) {
             return
+        }
 
         const bufferLines = await buffer.getLines(startRange - 1, endRange, false)
 

--- a/browser/src/neovim/NeovimInstance.ts
+++ b/browser/src/neovim/NeovimInstance.ts
@@ -179,7 +179,7 @@ export class NeovimInstance extends EventEmitter implements INeovimInstance {
         if (endRange > 10000)
             return
 
-        const bufferLines = await buffer.getLines(startRange, endRange, false)
+        const bufferLines = await buffer.getLines(startRange - 1, endRange, false)
 
         this._onFullBufferUpdateEvent.dispatch({
             context,

--- a/browser/src/neovim/NeovimInstance.ts
+++ b/browser/src/neovim/NeovimInstance.ts
@@ -172,21 +172,6 @@ export class NeovimInstance extends EventEmitter implements INeovimInstance {
         await this.command(`doautocmd <nomodeline> ${autoCommand}`)
     }
 
-    private async _onFullBufferUpdate(context: Oni.EventContext, startRange: number, endRange: number): Promise<void> {
-
-        const buffer = new Buffer(context.bufferNumber as any, this._neovim)
-
-        if (endRange > 10000)
-            return
-
-        const bufferLines = await buffer.getLines(startRange - 1, endRange, false)
-
-        this._onFullBufferUpdateEvent.dispatch({
-            context,
-            bufferLines,
-        })
-    }
-
     public start(filesToOpen?: string[]): Promise<void> {
         filesToOpen = filesToOpen || []
 
@@ -248,12 +233,6 @@ export class NeovimInstance extends EventEmitter implements INeovimInstance {
                             })
                         } else if (pluginMethod === "window_display_update") {
                             this.emit("window-display-update", args[0][0], args[0][1], args[0][2])
-                        } else if (pluginMethod === "api_info") {
-                            const apiVersion = args[0][0]
-                            if (apiVersion.api_level < 1) {
-                                alert("Please upgrade to at least Neovim 0.2.0")
-                            }
-
                         } else {
                             Log.warn("Unknown event from oni_plugin_notify: " + pluginMethod)
                         }
@@ -516,6 +495,21 @@ export class NeovimInstance extends EventEmitter implements INeovimInstance {
                 default:
                     Log.warn("Unhandled command: " + command)
             }
+        })
+    }
+
+    private async _onFullBufferUpdate(context: Oni.EventContext, startRange: number, endRange: number): Promise<void> {
+
+        const buffer = new Buffer(context.bufferNumber as any, this._neovim)
+
+        if (endRange > 10000)
+            return
+
+        const bufferLines = await buffer.getLines(startRange - 1, endRange, false)
+
+        this._onFullBufferUpdateEvent.dispatch({
+            context,
+            bufferLines,
         })
     }
 

--- a/browser/src/neovim/NeovimInstance.ts
+++ b/browser/src/neovim/NeovimInstance.ts
@@ -42,6 +42,13 @@ export interface IIncrementalBufferUpdateEvent {
     lineContents: string
 }
 
+// Limit for the number of lines to handle buffer updates
+// If the file is too large, it ends up being too much traffic
+// between Neovim <-> Oni <-> Language Servers - so 
+// set a hard limit. In the future, if need be, this could be
+// moved to a configuration setting.
+export const MAX_LINES_FOR_BUFFER_UPDATE = 5000
+
 export type NeovimEventHandler = (...args: any[]) => void
 
 export interface INeovimInstance {
@@ -504,7 +511,7 @@ export class NeovimInstance extends EventEmitter implements INeovimInstance {
 
         const buffer = new Buffer(context.bufferNumber as any, this._neovim)
 
-        if (endRange > 10000) {
+        if (endRange > MAX_LINES_FOR_BUFFER_UPDATE) {
             return
         }
 

--- a/browser/src/neovim/NeovimInstance.ts
+++ b/browser/src/neovim/NeovimInstance.ts
@@ -44,7 +44,7 @@ export interface IIncrementalBufferUpdateEvent {
 
 // Limit for the number of lines to handle buffer updates
 // If the file is too large, it ends up being too much traffic
-// between Neovim <-> Oni <-> Language Servers - so 
+// between Neovim <-> Oni <-> Language Servers - so
 // set a hard limit. In the future, if need be, this could be
 // moved to a configuration setting.
 export const MAX_LINES_FOR_BUFFER_UPDATE = 5000
@@ -268,7 +268,6 @@ export class NeovimInstance extends EventEmitter implements INeovimInstance {
                         performance.mark("NeovimInstance.Plugins.End")
 
                         configuration.activate(api)
-
 
                         // TODO: #702 - Batch these calls via `nvim_call_atomic`
                         // Override completeopt so Oni works correctly with external popupmenu

--- a/browser/src/neovim/NeovimInstance.ts
+++ b/browser/src/neovim/NeovimInstance.ts
@@ -185,9 +185,6 @@ export class NeovimInstance extends EventEmitter implements INeovimInstance {
 
                 this._neovim = nv
 
-                // Override completeopt so Oni works correctly with external popupmenu
-                this.command("set completeopt=longest,menu")
-
                 this._neovim.on("error", (err: Error) => {
                     Log.error(err)
                 })
@@ -264,6 +261,11 @@ export class NeovimInstance extends EventEmitter implements INeovimInstance {
                         performance.mark("NeovimInstance.Plugins.End")
 
                         configuration.activate(api)
+
+
+                        // TODO: #702 - Batch these calls via `nvim_call_atomic`
+                        // Override completeopt so Oni works correctly with external popupmenu
+                        await this.command("set completeopt=longest,menu")
 
                         // set title after attaching listeners so we can get the initial title
                         await this.command("set title")

--- a/browser/src/neovim/NeovimWindowManager.ts
+++ b/browser/src/neovim/NeovimWindowManager.ts
@@ -27,7 +27,7 @@ export class NeovimWindowManager extends EventEmitter {
         let win: IWindow
 
         // TODO: #702 - Good candidate to be consolidated via `nvim_call_atomic`
-        // In addition, would be nice to have `async/await` used here to clean up 
+        // In addition, would be nice to have `async/await` used here to clean up
         // the nested promise chain
         this._neovimInstance.getCurrentWindow()
             .then((currentWindow) => win = currentWindow)

--- a/browser/src/neovim/NeovimWindowManager.ts
+++ b/browser/src/neovim/NeovimWindowManager.ts
@@ -26,6 +26,9 @@ export class NeovimWindowManager extends EventEmitter {
 
         let win: IWindow
 
+        // TODO: #702 - Good candidate to be consolidated via `nvim_call_atomic`
+        // In addition, would be nice to have `async/await` used here to clean up 
+        // the nested promise chain
         this._neovimInstance.getCurrentWindow()
             .then((currentWindow) => win = currentWindow)
             .then(() => win.getDimensions())

--- a/vim/core/oni-core-interop/plugin/init.vim
+++ b/vim/core/oni-core-interop/plugin/init.vim
@@ -159,8 +159,6 @@ function OniUpdateWindowDisplayMap(shouldMeasure)
 endfunction
 
 function OniConnect()
-    call OniApiInfo()
-
     " Force BufEnter and buffer update events to be dispatched on connection
     " Otherwise, there can be race conditions where the buffer is loaded
     " prior to the UI attaching. See #122
@@ -170,15 +168,6 @@ endfunction
 
 function OniNotifyYank(yankEvent)
     call OniNotify(["oni_yank", a:yankEvent])
-endfunction
-
-
-function OniApiInfo()
-    if (has_key(api_info(),'version'))
-        call OniNotify(["api_info",api_info()["version"]])
-    else
-        call OniNotify(["api_info",{"api_level":0}])
-    endif
 endfunction
 
 

--- a/vim/core/oni-core-interop/plugin/init.vim
+++ b/vim/core/oni-core-interop/plugin/init.vim
@@ -25,8 +25,9 @@ function OniNotifyBufferUpdate()
         let b:last_change_tick = b:changedtick
         if mode() == 'i'
             let buffer_line = line(".")
+            let line_contents = getline(".")
             let context = OniGetContext()
-            call OniNotify(["buffer_update", context, buffer_line, buffer_line])
+            call OniNotify(["incremental_buffer_update", context, line_contents, buffer_line])
         else
             let context = OniGetContext()
             call OniNotify(["buffer_update", context, 1, line('$')])

--- a/vim/core/oni-core-interop/plugin/init.vim
+++ b/vim/core/oni-core-interop/plugin/init.vim
@@ -24,13 +24,12 @@ function OniNotifyBufferUpdate()
     if b:changedtick > b:last_change_tick
         let b:last_change_tick = b:changedtick
         if mode() == 'i'
-            let buffer_line = getline(".")
+            let buffer_line = line(".")
             let context = OniGetContext()
-            call OniNotify(["incremental_buffer_update", context, buffer_line, line(".")])
+            call OniNotify(["buffer_update", context, buffer_line, buffer_line])
         else
-            let buffer_lines = getline(1,"$")
             let context = OniGetContext()
-            call OniNotify(["buffer_update", context, buffer_lines])
+            call OniNotify(["buffer_update", context, 1, line('$')])
         endif
     endif
 endfunction


### PR DESCRIPTION
__Issue:__ When opening binaries (or any large file), Neovim crashes on windows. 

__Defect:__ When entering the buffer, we send a massive payload (the entire buffer contents) from Neovim -> Oni. This causes crashes in the large binary case, and may be a contributing factor to #490 as well.

__Fix:__ 
- Instead of a _push_ model, where Neovim always pushes buffer updates, switch to a _pull_ model, where Oni requests the buffer contents when necessary.
- Since Oni now decides when to _pull_ the buffer contents, we can put a hard limit on it - in this case, we'll only take in buffer updates if the file is <5000 lines.

> __NOTE:__ For incremental updates, we always send the individual line - that is still a _push_, but the data payload is much smaller. Since the latency is important (to show suggestion results quickly as the users types), it seemed reasonable to keep the incremental updates as-is.