### PR TITLE
Add link to syntax/compilation errors section of wiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Oni brings several IDE-like integrations to neovim:
 
 - [Quick Info](https://github.com/bryphe/oni/wiki/Features#quick-info)
 - [Code Completion](https://github.com/bryphe/oni/wiki/Features#code-completion)
-- Syntax / Compilation Errors
+- [Syntax / Compilation Errors](https://github.com/bryphe/oni/wiki/Features#syntax--compilation-errors)
 - [Fuzzy Finding](https://github.com/bryphe/oni/wiki/Features#fuzzy-finder)
 - [Status Bar](https://github.com/bryphe/oni/wiki/Features#status-bar)
 


### PR DESCRIPTION
It seemed weird for 'Syntax / Compilation Errors' to be the only Feature without a corresponding wiki link so I added a section to the wiki and added a link in the README.