### PR TITLE
Fix #713: Replace 'px' with 'em' for statusbar

### DIFF
--- a/browser/src/UI/components/StatusBar.less
+++ b/browser/src/UI/components/StatusBar.less
@@ -5,7 +5,7 @@
 
     color: @text-color;
     background-color: @background-color;
-    height: 28px;
+    height: 2.8em;
     position: relative;
     width: 100%;
 


### PR DESCRIPTION
__Issue:__ Previous fixes replaced several cases where we were using `px` instead of `em` (which cause problem in HDPI displays). However, the actual height of the statusbar was still using `px`, so even though the font height was fixed, the status bar height wasn't.

__Fix:__ Replace the `28px` with an `em` value.