### PR TITLE
Fix #690: Fix the 'No matching autocmd' error in the general case

### DIFF
--- a/browser/src/neovim/NeovimInstance.ts
+++ b/browser/src/neovim/NeovimInstance.ts
@@ -144,7 +144,11 @@ export class NeovimInstance extends EventEmitter implements INeovimInstance {
     }
 
     public async executeAutoCommand(autoCommand: string): Promise<void> {
-        await this.command(`doautocmd <nomodeline> ${autoCommand}`)
+        const doesAutoCommandExist = await this.eval(`exists('#${autoCommand}')`)
+
+        if (doesAutoCommandExist) {
+            await this.command(`doautocmd <nomodeline> ${autoCommand}`)
+        }
     }
 
     public start(filesToOpen?: string[]): Promise<void> {

--- a/vim/core/oni-core-interop/plugin/init.vim
+++ b/vim/core/oni-core-interop/plugin/init.vim
@@ -59,14 +59,6 @@ augroup OniClipboard
     autocmd! TextYankPost * :call OniNotifyYank(v:event)
 augroup end
 
-" Prevent 'no matching autocommand' message if FocusLost/FocusGained
-" aren't registered
-augroup OniNoop
-    autocmd!
-    autocmd! FocusLost * :call OniNoop()
-    autocmd! FocusGained * :call OniNoop()
-augroup END
-
 augroup OniNotifyBufferUpdates
     autocmd!
     autocmd! CursorMovedI * :call OniNotifyBufferUpdate()


### PR DESCRIPTION
__Issue:__ The `executeAutoCommand` method blindly executes `doautocmd` without checking if there is an autocommand registered. This causes a 'No Matching Autocommand' message to be displayed.

__Fix:__ Check for existence of the autocommand prior to executing. Note that there is a potential race condition here, if the autocmd gets registered between the check and the execution, but because the impact is minimal (the worst case would be, showing the 'No Matching Autocommand' message), I believe the fix is reasonable. I explored using `nvim_call_atomic` for this case but I didn't see a way to gate the `doautocmd` call based on the result of the `exists` call.