### PR TITLE
[WIP] Allow the passing of a custom init.vim path.

### DIFF
--- a/browser/src/Services/Commands.ts
+++ b/browser/src/Services/Commands.ts
@@ -53,7 +53,7 @@ export const registerBuiltInCommands = (commandManager: CommandManager, pluginMa
         // Menu commands
         new CallbackCommand("oni.config.openConfigJs", "Edit Oni Config", "Edit configuration file ('config.js') for Oni", () => openDefaultConfig(neovimInstance)),
 
-        new CallbackCommand("oni.config.openInitVim", "Edit Neovim Config", "Edit configuration file ('init.vim') for Neovim", () => neovimInstance.open("$MYVIMRC")),
+        new CallbackCommand("oni.config.openInitVim", "Edit Neovim Config", "Edit configuration file ('init.vim') for Neovim", () => neovimInstance.openInitVim()),
 
         new CallbackCommand("oni.openFolder", "Open Folder", "Set a folder as the working directory for Oni", () => openFolder(neovimInstance)),
 

--- a/browser/src/Services/Configuration/DefaultConfiguration.ts
+++ b/browser/src/Services/Configuration/DefaultConfiguration.ts
@@ -25,7 +25,6 @@ const BaseConfiguration: IConfigurationValues = {
     "oni.useDefaultConfig": true,
 
     "oni.loadInitVim": false,
-    "oni.customInitVimPath" : "",
 
     "oni.useExternalPopupMenu": true,
 

--- a/browser/src/Services/Configuration/DefaultConfiguration.ts
+++ b/browser/src/Services/Configuration/DefaultConfiguration.ts
@@ -25,6 +25,7 @@ const BaseConfiguration: IConfigurationValues = {
     "oni.useDefaultConfig": true,
 
     "oni.loadInitVim": false,
+    "oni.customInitVimPath" : "",
 
     "oni.useExternalPopupMenu": true,
 

--- a/browser/src/Services/Configuration/IConfigurationValues.ts
+++ b/browser/src/Services/Configuration/IConfigurationValues.ts
@@ -34,10 +34,8 @@ export interface IConfigurationValues {
 
     // By default, user's init.vim is not loaded, to avoid conflicts.
     // Set this to `true` to enable loading of init.vim.
-    "oni.loadInitVim": boolean
-
-    // Option to override init.vim path.
-    "oni.customInitVimPath": string
+    // Set this to a string to override the init.vim path.
+    "oni.loadInitVim": string | boolean
 
     // Sets the `popupmenu_external` option in Neovim
     // This will override the default UI to show a consistent popupmenu,

--- a/browser/src/Services/Configuration/IConfigurationValues.ts
+++ b/browser/src/Services/Configuration/IConfigurationValues.ts
@@ -36,6 +36,9 @@ export interface IConfigurationValues {
     // Set this to `true` to enable loading of init.vim.
     "oni.loadInitVim": boolean
 
+    // Option to override init.vim path.
+    "oni.customInitVimPath": string
+
     // Sets the `popupmenu_external` option in Neovim
     // This will override the default UI to show a consistent popupmenu,
     // whether using Oni's completion mechanisms or VIMs

--- a/browser/src/neovim/NeovimInstance.ts
+++ b/browser/src/neovim/NeovimInstance.ts
@@ -326,12 +326,12 @@ export class NeovimInstance extends EventEmitter implements INeovimInstance {
     }
 
     public openInitVim(): Promise<void> {
-        const customInitVimPath = configuration.getValue("oni.customInitVimPath")
+        const loadInitVim = configuration.getValue("oni.loadInitVim")
 
-        if (customInitVimPath) {
-            return this.command(`e! ${customInitVimPath}`)
+        if (typeof(loadInitVim) === 'string') {
+            return this.open(loadInitVim)
         } else {
-            return this.command(`e! $MYVIMRC`)
+            return this.open('$MYVIMRC')
         }
     }
 

--- a/browser/src/neovim/NeovimInstance.ts
+++ b/browser/src/neovim/NeovimInstance.ts
@@ -109,6 +109,7 @@ export interface INeovimInstance {
     getApiVersion(): Promise<INeovimApiVersion>
 
     open(fileName: string): Promise<void>
+    openInitVim(): Promise<void>
 
     executeAutoCommand(autoCommand: string): Promise<void>
 }
@@ -322,6 +323,16 @@ export class NeovimInstance extends EventEmitter implements INeovimInstance {
 
     public open(fileName: string): Promise<void> {
         return this.command(`e! ${fileName}`)
+    }
+
+    public openInitVim(): Promise<void> {
+        const customInitVimPath = configuration.getValue("oni.customInitVimPath")
+
+        if (customInitVimPath){
+            return this.command(`e! ${customInitVimPath}`)
+        } else {
+            return this.command(`e! $MYVIMRC`)
+        }
     }
 
     public eval<T>(expression: string): Promise<T> {

--- a/browser/src/neovim/NeovimInstance.ts
+++ b/browser/src/neovim/NeovimInstance.ts
@@ -328,7 +328,7 @@ export class NeovimInstance extends EventEmitter implements INeovimInstance {
     public openInitVim(): Promise<void> {
         const customInitVimPath = configuration.getValue("oni.customInitVimPath")
 
-        if (customInitVimPath){
+        if (customInitVimPath) {
             return this.command(`e! ${customInitVimPath}`)
         } else {
             return this.command(`e! $MYVIMRC`)

--- a/browser/src/neovim/NeovimInstance.ts
+++ b/browser/src/neovim/NeovimInstance.ts
@@ -328,10 +328,10 @@ export class NeovimInstance extends EventEmitter implements INeovimInstance {
     public openInitVim(): Promise<void> {
         const loadInitVim = configuration.getValue("oni.loadInitVim")
 
-        if (typeof(loadInitVim) === 'string') {
+        if (typeof(loadInitVim) === "string") {
             return this.open(loadInitVim)
         } else {
-            return this.open('$MYVIMRC')
+            return this.open("$MYVIMRC")
         }
     }
 

--- a/browser/src/neovim/NeovimProcessSpawner.ts
+++ b/browser/src/neovim/NeovimProcessSpawner.ts
@@ -37,14 +37,14 @@ export const startNeovim = (runtimePaths: string[], args: string[]): Session => 
                                     .map((p) => remapPathToUnpackedAsar(p))
                                     .join(",")
 
-    const shouldLoadInitVim = configuration.getValue("oni.loadInitVim")
+    const loadInitVimConfigOption = configuration.getValue("oni.loadInitVim")
     const useDefaultConfig = configuration.getValue("oni.useDefaultConfig")
 
     let initVimArg = []
-    initVimArg = (shouldLoadInitVim || !useDefaultConfig) ? [] : ["-u", noopInitVimPath]
+    initVimArg = (loadInitVimConfigOption || !useDefaultConfig) ? [] : ["-u", noopInitVimPath]
 
-    if (typeof(shouldLoadInitVim) === 'string') {
-        initVimArg = ["-u", shouldLoadInitVim]
+    if (typeof(loadInitVimConfigOption) === 'string') {
+        initVimArg = ["-u", loadInitVimConfigOption]
     }
 
     const argsToPass = initVimArg

--- a/browser/src/neovim/NeovimProcessSpawner.ts
+++ b/browser/src/neovim/NeovimProcessSpawner.ts
@@ -38,11 +38,17 @@ export const startNeovim = (runtimePaths: string[], args: string[]): Session => 
                                     .join(",")
 
     const shouldLoadInitVim = configuration.getValue("oni.loadInitVim")
+    const customInitVimPath = configuration.getValue("oni.customInitVimPath")
     const useDefaultConfig = configuration.getValue("oni.useDefaultConfig")
 
-    const vimRcArg = (shouldLoadInitVim || !useDefaultConfig) ? [] : ["-u", noopInitVimPath]
+    let initVimArg = []
+    initVimArg = (shouldLoadInitVim || !useDefaultConfig) ? [] : ["-u", noopInitVimPath]
 
-    const argsToPass = vimRcArg
+    if ((shouldLoadInitVim || !useDefaultConfig) && customInitVimPath) {
+        initVimArg = ["-u", customInitVimPath]
+    }
+
+    const argsToPass = initVimArg
         .concat(["--cmd", `let &rtp.='${joinedRuntimePaths}'`, "--cmd", "let g:gui_oni = 1", "-N", "--embed", "--"])
         .concat(args)
 

--- a/browser/src/neovim/NeovimProcessSpawner.ts
+++ b/browser/src/neovim/NeovimProcessSpawner.ts
@@ -43,7 +43,7 @@ export const startNeovim = (runtimePaths: string[], args: string[]): Session => 
     let initVimArg = []
     initVimArg = (loadInitVimConfigOption || !useDefaultConfig) ? [] : ["-u", noopInitVimPath]
 
-    if (typeof(loadInitVimConfigOption) === 'string') {
+    if (typeof(loadInitVimConfigOption) === "string") {
         initVimArg = ["-u", loadInitVimConfigOption]
     }
 

--- a/browser/src/neovim/NeovimProcessSpawner.ts
+++ b/browser/src/neovim/NeovimProcessSpawner.ts
@@ -38,14 +38,13 @@ export const startNeovim = (runtimePaths: string[], args: string[]): Session => 
                                     .join(",")
 
     const shouldLoadInitVim = configuration.getValue("oni.loadInitVim")
-    const customInitVimPath = configuration.getValue("oni.customInitVimPath")
     const useDefaultConfig = configuration.getValue("oni.useDefaultConfig")
 
     let initVimArg = []
     initVimArg = (shouldLoadInitVim || !useDefaultConfig) ? [] : ["-u", noopInitVimPath]
 
-    if ((shouldLoadInitVim || !useDefaultConfig) && customInitVimPath) {
-        initVimArg = ["-u", customInitVimPath]
+    if (typeof(shouldLoadInitVim) === 'string') {
+        initVimArg = ["-u", shouldLoadInitVim]
     }
 
     const argsToPass = initVimArg


### PR DESCRIPTION
This PR should allow the defining of a custom init.vim path in the Oni config file.

I need to check into some error checking, ie if an incorrect path is given, as well as some testing outside of Windows (Mac or Linux users would be useful, since I've only got Window + a few Linux VMs).

Also, is it acceptable to assume the user will sufficiently escape the path they provide?
Ie if they are on Windows and their init.vim is at `"C:\Users\CrossR\init.vim"`, they would need to set it with escaped back slashes as follows:

`"oni.customInitVimPath" : "C:\\Users\\CrossR\\init.vim"`.

Also since this is applied as an argument at startup, setting a custom path isn't applied until restarting oni currently. Is it worth looking into applying it straight away, or should that be a separate PR?