### PR TITLE
Add `oni.enhancedSyntaxHighlighting` option

### DIFF
--- a/browser/src/Services/Configuration/DefaultConfiguration.ts
+++ b/browser/src/Services/Configuration/DefaultConfiguration.ts
@@ -24,6 +24,8 @@ const BaseConfiguration: IConfigurationValues = {
 
     "oni.useDefaultConfig": true,
 
+    "oni.enhancedSyntaxHighlighting": true,
+
     "oni.loadInitVim": false,
 
     "oni.useExternalPopupMenu": true,

--- a/browser/src/Services/Configuration/IConfigurationValues.ts
+++ b/browser/src/Services/Configuration/IConfigurationValues.ts
@@ -26,6 +26,10 @@ export interface IConfigurationValues {
     // See `:help bell` for instances where the bell sound would be used
     "oni.audio.bellUrl": string
 
+    // Set this to `true` to enable additional syntax highlighting
+    // from Oni & language integrations
+    "oni.enhancedSyntaxHighlighting": boolean
+
     // The default config is an opinionated, prescribed set of plugins. This is on by default to provide
     // a good out-of-box experience, but will likely conflict with a Vim/Neovim veteran's finely honed config.
     //

--- a/browser/src/Services/SyntaxHighlighter.ts
+++ b/browser/src/Services/SyntaxHighlighter.ts
@@ -6,6 +6,8 @@ import * as Log from "./../Log"
 import { IBuffer, INeovimInstance } from "./../neovim"
 import { PluginManager } from "./../Plugins/PluginManager"
 
+import { configuration } from "./Configuration"
+
 import { SymbolKind } from "vscode-languageserver-types"
 
 const symbolKindToHighlightString = (kind: SymbolKind): string => {
@@ -51,6 +53,11 @@ export class SyntaxHighlighter {
         this._pluginManager = pluginManager
 
         this._pluginManager.on("set-syntax-highlights", (payload: any) => {
+
+            if (!configuration.getValue("oni.enhancedSyntaxHighlighting")) {
+                return
+            }
+
             let buf: IBuffer = null as any // FIXME: null
             this._neovimInstance.getCurrentBuffer()
                 .then((buffer) => buf = buffer)


### PR DESCRIPTION
I believe that the custom syntax highlighting that Oni does may be a contributing factor for #664 and #490 . I want to test that hypothesis, and having a setting to disable it can help confirm or rule it out as a contributing factor.