### PR TITLE
Refactoring: Clean up unnecessary actions

### DIFF
--- a/browser/src/Editor/NeovimEditor.tsx
+++ b/browser/src/Editor/NeovimEditor.tsx
@@ -331,9 +331,7 @@ export class NeovimEditor implements IEditor {
                 language: evt.filetype,
             })
 
-            // TODO: More convenient way to hide all UI?
             UI.Actions.hideCompletions()
-            UI.Actions.hidePopupMenu()
             UI.Actions.hideSignatureHelp()
 
             UI.Actions.bufferEnter(evt.bufferNumber, evt.bufferFullPath, evt.bufferTotalLines, evt.hidden, evt.listed)

--- a/browser/src/Editor/NeovimEditor.tsx
+++ b/browser/src/Editor/NeovimEditor.tsx
@@ -305,16 +305,9 @@ export class NeovimEditor implements IEditor {
         this._onModeChangedEvent.dispatch(newMode)
 
         if (newMode === "normal") {
-            UI.Actions.showCursorLine()
-            UI.Actions.showCursorColumn()
             UI.Actions.hideCompletions()
             UI.Actions.hideSignatureHelp()
-        } else if (newMode === "insert") {
-            UI.Actions.showCursorColumn()
-            UI.Actions.showCursorLine()
         } else if (newMode.indexOf("cmdline") >= 0) {
-            UI.Actions.hideCursorLine()
-            UI.Actions.hideCursorColumn() // TODO: cleaner way to hide and unhide?
             UI.Actions.hideCompletions()
         }
     }

--- a/browser/src/UI/ActionCreators.ts
+++ b/browser/src/UI/ActionCreators.ts
@@ -313,14 +313,6 @@ export const hideCompletions = () => ({ type: "HIDE_AUTO_COMPLETION" })
 
 export const hideQuickInfo = () => ({ type: "HIDE_QUICK_INFO" })
 
-export const hideCursorLine = () => ({ type: "HIDE_CURSOR_LINE" })
-
-export const showCursorLine = () => ({ type: "SHOW_CURSOR_LINE" })
-
-export const showCursorColumn = () => ({ type: "SHOW_CURSOR_COLUMN" })
-
-export const hideCursorColumn = () => ({ type: "HIDE_CURSOR_COLUMN" })
-
 export const setCursorLineOpacity = (opacity: number) => ({
     type: "SET_CURSOR_LINE_OPACITY",
     payload: {

--- a/browser/src/UI/Actions.ts
+++ b/browser/src/UI/Actions.ts
@@ -260,22 +260,6 @@ export interface IHideQuickInfoAction {
     type: "HIDE_QUICK_INFO"
 }
 
-export interface IShowCursorLineAction {
-    type: "SHOW_CURSOR_LINE"
-}
-
-export interface IHideCurorLineAction {
-    type: "HIDE_CURSOR_LINE"
-}
-
-export interface IShowCursorColumnAction {
-    type: "SHOW_CURSOR_COLUMN"
-}
-
-export interface IHideCursorColumnAction {
-    type: "HIDE_CURSOR_COLUMN"
-}
-
 export interface ISetConfigurationValue<K extends keyof IConfigurationValues> {
     type: "SET_CONFIGURATION_VALUE"
     payload: {

--- a/browser/src/UI/Actions.ts
+++ b/browser/src/UI/Actions.ts
@@ -298,12 +298,8 @@ export type SimpleAction =
     ISetColorsAction |
     IStatusBarHideAction |
     IStatusBarShowAction |
-    IHideCurorLineAction |
-    IHideCursorColumnAction |
     ISetErrorsAction |
     IClearErrorsAction |
-    IShowCursorLineAction |
-    IShowCursorColumnAction |
     ISetCurrentBuffersAction |
     ISetTabs |
     ISetViewportAction |

--- a/browser/src/UI/Reducer.ts
+++ b/browser/src/UI/Reducer.ts
@@ -77,18 +77,6 @@ export function reducer<K extends keyof IConfigurationValues>(s: State.IState, a
         case "HIDE_SIGNATURE_HELP":
             return {...s,
                     signatureHelp: null}
-         case "HIDE_CURSOR_LINE":
-             return {...s,
-                     cursorLineVisible: false}
-         case "HIDE_CURSOR_COLUMN":
-             return {...s,
-                     cursorColumnVisible: false}
-         case "SHOW_CURSOR_LINE":
-             return {...s,
-                     cursorLineVisible: true}
-         case "SHOW_CURSOR_COLUMN":
-             return {...s,
-                     cursorColumnVisible: true}
         case "SET_CONFIGURATION_VALUE":
             const obj: Partial<IConfigurationValues> = {}
             obj[a.payload.key] = a.payload.value

--- a/browser/src/UI/State.ts
+++ b/browser/src/UI/State.ts
@@ -49,9 +49,7 @@ export interface IState {
     quickInfo: null | ILocatable<Oni.Plugin.QuickInfo>
     popupMenu: null | IMenu
     signatureHelp: null | Oni.Plugin.SignatureHelpResult
-    cursorLineVisible: boolean
     cursorLineOpacity: number
-    cursorColumnVisible: boolean
     cursorColumnOpacity: number
     configuration: IConfigurationValues
     imeActive: boolean
@@ -215,9 +213,7 @@ export const createDefaultState = (): IState => ({
         width: 0,
         height: 0,
     },
-    cursorLineVisible: false,
     cursorLineOpacity: 0,
-    cursorColumnVisible: false,
     cursorColumnOpacity: 0,
     backgroundColor: "#000000",
 

--- a/browser/src/UI/components/CursorLine.tsx
+++ b/browser/src/UI/components/CursorLine.tsx
@@ -50,6 +50,8 @@ const mapStateToProps = (state: State.IState, props: ICursorLineProps) => {
     const enabledSetting = props.lineType === "line" ? "editor.cursorLine" : "editor.cursorColumn"
     const enabled = state.configuration[enabledSetting]
 
+    const isNormalInsertOrVisualMode = state.mode === "normal" || state.mode === "insert" || state.mode === "visual"
+
     const isVisible = props.lineType === "line" ? state.cursorLineVisible : state.cursorColumnVisible
 
     const activeWindowDimensions = Selectors.getActiveWindowDimensions(state)
@@ -60,7 +62,7 @@ const mapStateToProps = (state: State.IState, props: ICursorLineProps) => {
         width: props.lineType === "line" ? activeWindowDimensions.width : state.cursorPixelWidth,
         height: props.lineType === "line" ? state.fontPixelHeight : activeWindowDimensions.height,
         color: state.foregroundColor,
-        visible: isVisible && enabled,
+        visible: isVisible && enabled & isNormalInsertOrVisualMode,
         opacity,
     }
 }

--- a/browser/src/UI/components/CursorLine.tsx
+++ b/browser/src/UI/components/CursorLine.tsx
@@ -17,8 +17,6 @@ export interface ICursorLineProps {
     lineType: string
 }
 
-// require("./Cursor.less") // tslint:disable-line no-var-requires
-
 class CursorLineRenderer extends React.PureComponent<ICursorLineRendererProps, void> {
 
     public render(): null |  JSX.Element {
@@ -52,8 +50,6 @@ const mapStateToProps = (state: State.IState, props: ICursorLineProps) => {
 
     const isNormalInsertOrVisualMode = state.mode === "normal" || state.mode === "insert" || state.mode === "visual"
 
-    const isVisible = props.lineType === "line" ? state.cursorLineVisible : state.cursorColumnVisible
-
     const activeWindowDimensions = Selectors.getActiveWindowDimensions(state)
 
     return {
@@ -62,7 +58,7 @@ const mapStateToProps = (state: State.IState, props: ICursorLineProps) => {
         width: props.lineType === "line" ? activeWindowDimensions.width : state.cursorPixelWidth,
         height: props.lineType === "line" ? state.fontPixelHeight : activeWindowDimensions.height,
         color: state.foregroundColor,
-        visible: isVisible && enabled & isNormalInsertOrVisualMode,
+        visible: enabled && isNormalInsertOrVisualMode,
         opacity,
     }
 }


### PR DESCRIPTION
It turns out there are several actions that are not needed (`show/hide` + `cursorLine`/`cursorColumn`). When the cursor line / cursor column feature was implemented, the mode + configuration wasn't in the store. However, since it is now, it can be derived entirely from the state instead of being toggled on/off in NeovimEditor.
