### PR TITLE
Change quit to quit app instead of close current window

### DIFF
--- a/browser/src/Services/Commands.ts
+++ b/browser/src/Services/Commands.ts
@@ -38,7 +38,7 @@ export const registerBuiltInCommands = (commandManager: CommandManager, pluginMa
         new CallbackCommand("editor.clipboard.paste", "Clipboard: Paste", "Paste clipboard contents into active text", () => pasteContents(neovimInstance)),
         new CallbackCommand("editor.clipboard.yank", "Clipboard: Yank", "Yank contents to clipboard", () => neovimInstance.input("y")),
 
-        new CallbackCommand("oni.quit", null, null, () => remote.getCurrentWindow().close()),
+        new CallbackCommand("oni.quit", null, null, () => remote.app.quit()),
 
         // Debug
         new CallbackCommand("oni.debug.openDevTools", "Open DevTools", "Debug Oni and any running plugins using the Chrome developer tools", () => remote.getCurrentWindow().webContents.openDevTools()),


### PR DESCRIPTION
Quit was previously only closing the current window, this meant that the application didn't quit as expected when on OSX. This fixes that issue and causes the whole application to quit.