### PR TITLE
Make QuickInfo standout on dark themes

### DIFF
--- a/browser/src/UI/components/QuickInfo.less
+++ b/browser/src/UI/components/QuickInfo.less
@@ -9,6 +9,7 @@
 
     .quickinfo {
         .box-shadow;
+        border: 1px solid #333333;
 
         text-overflow: ellipsis;
         overflow: hidden;
@@ -21,6 +22,7 @@
 
         .documentation {
             .box-shadow-inset;
+            border-top: 1px solid #222222;
             padding: 8px;
             font-size: @font-size-small;
             min-width: 300px;


### PR DESCRIPTION
I found difficult to read the quick info box on a dark vim color scheme, so I added a border color to it.
This PR is more a suggestion then the "final product", not sure if you have something else in mind to solve this problem.

## Now 
<img width="1440" alt="screen shot 2017-10-12 at 8 39 25 am" src="https://user-images.githubusercontent.com/230476/31505252-552fc828-af29-11e7-9a4e-e070bd093a85.png">

## Before
<img width="1439" alt="screen shot 2017-10-12 at 8 45 39 am" src="https://user-images.githubusercontent.com/230476/31505460-cad9a954-af29-11e7-9e90-d20a7b80fba1.png">
