### PR TITLE
Make notification handler be more immutable

### DIFF
--- a/browser/src/neovim/NeovimInstance.ts
+++ b/browser/src/neovim/NeovimInstance.ts
@@ -436,7 +436,9 @@ export class NeovimInstance extends EventEmitter implements INeovimInstance {
 
     private _handleNotification(_method: any, args: any): void {
         args.forEach((a: any[]) => {
-            const command = a.shift()
+            const command = a[0]
+            a = a.slice(1)
+
             switch (command) {
                 case "cursor_goto":
                     this.emit("action", Actions.createCursorGotoAction(a[0][0], a[0][1]))


### PR DESCRIPTION
This patch creates a new array array instead of mutating the existing array `a`.

While playing and debugging the neovim Session code, I noticed that a lot of the data I was consoling out from the notification event handler was missing the command name. It is because the arguments array returned from the notification event was being mutated in place by this code. Objects in the console are late bound, so they don't know their values at the time of logging.