### PR TITLE
Add additional debug logging / settings for #490

### DIFF
--- a/browser/src/Services/Configuration/DefaultConfiguration.ts
+++ b/browser/src/Services/Configuration/DefaultConfiguration.ts
@@ -19,6 +19,8 @@ const BaseConfiguration: IConfigurationValues = {
 
     "debug.fixedSize": null,
     "debug.neovimPath": null,
+    "debug.persistOnNeovimExit": true,
+    "debug.detailedSessionLogging": false,
 
     "experimental.enableLanguageServerFromConfig": false,
 

--- a/browser/src/Services/Configuration/DefaultConfiguration.ts
+++ b/browser/src/Services/Configuration/DefaultConfiguration.ts
@@ -19,7 +19,7 @@ const BaseConfiguration: IConfigurationValues = {
 
     "debug.fixedSize": null,
     "debug.neovimPath": null,
-    "debug.persistOnNeovimExit": true,
+    "debug.persistOnNeovimExit": false,
     "debug.detailedSessionLogging": false,
 
     "experimental.enableLanguageServerFromConfig": false,

--- a/browser/src/Services/Configuration/IConfigurationValues.ts
+++ b/browser/src/Services/Configuration/IConfigurationValues.ts
@@ -20,6 +20,9 @@ export interface IConfigurationValues {
     // Option to override neovim path. Used for testing new versions before bringing them in.
     "debug.neovimPath": string | null
 
+    "debug.persistOnNeovimExit": boolean
+    "debug.detailedSessionLogging": boolean
+
     // Experimental feature flags
 
     "experimental.enableLanguageServerFromConfig": boolean

--- a/browser/src/neovim/NeovimInstance.ts
+++ b/browser/src/neovim/NeovimInstance.ts
@@ -255,7 +255,10 @@ export class NeovimInstance extends EventEmitter implements INeovimInstance {
                 })
 
                 this._neovim.on("disconnect", () => {
-                    remote.getCurrentWindow().close()
+
+                    if (!configuration.getValue("debug.persistOnNeovimExit")) {
+                        remote.getCurrentWindow().close()
+                    }
                 })
 
                 const size = this._getSize()

--- a/browser/src/neovim/NeovimInstance.ts
+++ b/browser/src/neovim/NeovimInstance.ts
@@ -343,6 +343,7 @@ export class NeovimInstance extends EventEmitter implements INeovimInstance {
     }
 
     public command(command: string): Promise<void> {
+        Log.verbose("[NeovimInstance] Executing command: " + command)
         return this._neovim.request("nvim_command", [command])
     }
 

--- a/browser/src/neovim/Session.ts
+++ b/browser/src/neovim/Session.ts
@@ -53,8 +53,6 @@ export class Session extends EventEmitter {
                     Log.warn("Unhandled request")
                     break
                 case 1 /* Response */:
-
-
                     const [responseMessage, payload1, payload2] = remaining
                     const result = payload1 || payload2
                     log("Received response - "  + responseMessage + " : " + result)

--- a/browser/src/neovim/Session.ts
+++ b/browser/src/neovim/Session.ts
@@ -4,9 +4,17 @@ import { EventEmitter } from "events"
 
 import * as Log from "./../Log"
 
+import { configuration } from "./../Services/Configuration"
+
 import * as msgpack from "./MsgPack"
 
 type RequestHandlerFunction = (result: any) => void
+
+const log = (msg: string) => {
+    if (configuration.getValue("debug.detailedSessionLogging")) {
+        Log.info("[DEBUG - Neovim Session] " + msg)
+    }
+}
 
 /**
  * Session is responsible for the Neovim msgpack session
@@ -45,12 +53,16 @@ export class Session extends EventEmitter {
                     Log.warn("Unhandled request")
                     break
                 case 1 /* Response */:
+
+
                     const [responseMessage, payload1, payload2] = remaining
                     const result = payload1 || payload2
+                    log("Received response - "  + responseMessage + " : " + result)
                     this._pendingRequests[responseMessage](result)
                     break
                 case 2 /* Notification */:
                     const [notificationMessage, payload] = remaining
+                    log("Received notification - " + notificationMessage)
 
                     this.emit("notification", notificationMessage, payload)
                     break
@@ -60,6 +72,7 @@ export class Session extends EventEmitter {
         })
 
         this._decoder.on("end", () => {
+            log("Disconnect")
             this.emit("disconnect")
         })
 
@@ -81,6 +94,8 @@ export class Session extends EventEmitter {
             return Promise.reject(null)
         }
 
+        log("Sending request - " + methodName + " : " + this._requestId)
+
         this._pendingRequests[this._requestId] = r
         this._writeImmediate([0, this._requestId, methodName, args])
 
@@ -88,6 +103,7 @@ export class Session extends EventEmitter {
     }
 
     public notify(methodName: string, args: any) {
+        log("Sending notification - " + methodName)
         this._writeImmediate([2, methodName, args])
     }
 


### PR DESCRIPTION
Still looking at #490 and trying to isolate the cases where it crashes. This change adds two additional configuration parameters to assist in the debugging:
`debug.persistOnNeovimExit` - if set to `true`, Oni will stay open when Neovim exits. This makes it easier to look at the logs in the case of a crash. Of course, `:q` won't work as expected here, since Oni will still be open, so it's really only useful for debugging.
`debug.detailedSessionLogging` - if set to `true`, Oni will log out all the session traffic to Neovim. Ideally, instead of a setting, this should be reconciled with the `verbose`/`info`/`debug` log levels.