### PR TITLE
Fix regression in completion

### DIFF
--- a/browser/src/Editor/NeovimEditor.tsx
+++ b/browser/src/Editor/NeovimEditor.tsx
@@ -12,7 +12,7 @@ import * as types from "vscode-languageserver-types"
 import { clipboard, ipcRenderer, remote } from "electron"
 
 import { IncrementalDeltaRegionTracker } from "./../DeltaRegionTracker"
-import { NeovimInstance, NeovimWindowManager } from "./../neovim"
+import { IFullBufferUpdateEvent, IIncrementalBufferUpdateEvent, NeovimInstance, NeovimWindowManager } from "./../neovim"
 import { CanvasRenderer, INeovimRenderer } from "./../Renderer"
 import { NeovimScreen } from "./../Screen"
 
@@ -189,11 +189,13 @@ export class NeovimEditor implements IEditor {
 
         this._neovimInstance.on("mode-change", (newMode: string) => this._onModeChanged(newMode))
 
-        this._neovimInstance.on("buffer-update", (args: Oni.EventContext) => {
+        this._neovimInstance.onBufferUpdate.subscribe((bufferUpdateEvent: IFullBufferUpdateEvent) => {
+            const args = bufferUpdateEvent.context
             UI.Actions.bufferUpdate(args.bufferNumber, args.modified, args.version, args.bufferTotalLines)
         })
 
-        this._neovimInstance.on("buffer-update-incremental", (args: Oni.EventContext) => {
+        this._neovimInstance.onBufferUpdateIncremental.subscribe((bufferUpdateEvent: IIncrementalBufferUpdateEvent) => {
+            const args = bufferUpdateEvent.context
             UI.Actions.bufferUpdate(args.bufferNumber, args.modified, args.version, args.bufferTotalLines)
         })
 

--- a/browser/src/Plugins/PluginManager.ts
+++ b/browser/src/Plugins/PluginManager.ts
@@ -106,6 +106,11 @@ export class PluginManager extends EventEmitter {
                 bufferLine,
             },
         }, Capabilities.createPluginFilter(eventContext.filetype))
+
+        if (this._config.getValue("editor.completions.enabled")) {
+            this._sendLanguageServiceRequest("signature-help", eventContext)
+            this._sendLanguageServiceRequest("completion-provider", eventContext)
+        }
     }
 
     private _createPlugin(pluginRootDirectory: string): Plugin {
@@ -206,11 +211,6 @@ export class PluginManager extends EventEmitter {
 
         if (eventName === "CursorMoved" && this._config.getValue("editor.quickInfo.enabled")) {
             this._sendLanguageServiceRequest("quick-info", eventContext)
-
-        } else if (eventName === "CursorMovedI" && this._config.getValue("editor.completions.enabled")) {
-            this._sendLanguageServiceRequest("completion-provider", eventContext)
-
-            this._sendLanguageServiceRequest("signature-help", eventContext)
         }
     }
 


### PR DESCRIPTION
PR #777 (which fixes #473) introduced a subtle regression in completion. Prior to this change, the plugins would first get a `buffer-update` event, followed by a `completions` request. However, after this change, because it adjusted the strategy for getting buffer contents, the `buffer-update` came _after_ the `completions` request, so we would often be asking for completions for an empty space or an invalid location.

This moves the completion request to occur after incremental buffer updates (which only happen in insert mode currently), so that we can guarantee they come _after_ the buffer update, instead of being associated with the `CursorMovedI` event. This will likely change a bit as the language responsibilities are factored out from `PluginManager`.