### PR TITLE
Add border for QuickInfo UI

### DIFF
--- a/browser/src/UI/components/Arrow.less
+++ b/browser/src/UI/components/Arrow.less
@@ -1,0 +1,25 @@
+@import (reference) "./common.less";
+
+.arrow {
+    animation-duration: 0.3s;
+    animation-delay: 0.2s;
+    opacity: 0;
+    animation-fill-mode: forwards;
+
+    &.down {
+        animation-name: appear-down;
+    }
+
+    &.up {
+        animation-name: appear-up;
+    }
+}
+
+@keyframes appear-down {
+    from {transform: translateY(-4px); opacity: 0;}
+    to {transform: translateY(0px);opacity: 1;}
+}
+@keyframes appear-up {
+    from {transform: translateY(4px); opacity: 0;}
+    to {transform: translateY(0px);opacity: 1;}
+}

--- a/browser/src/UI/components/Arrow.tsx
+++ b/browser/src/UI/components/Arrow.tsx
@@ -4,6 +4,8 @@
  * Simple 'up' or 'down' arrow component
  */
 
+require("./Arrow.less") // tslint:disable-line no-var-requires
+
 import * as React from "react"
 
 export enum ArrowDirection {
@@ -38,7 +40,9 @@ export const Arrow = (props: IArrowProps): JSX.Element => {
         borderTop: solidBorder,
     }
 
-    const style = props.direction === ArrowDirection.Up ? upArrowStyle : downArrowStyle
+    const isUp = props.direction === ArrowDirection.Up
+    const style = isUp ? upArrowStyle : downArrowStyle
+    const className = isUp ? "arrow up" : "arrow down"
 
-    return <div style={style}></div>
+    return <div className={className} style={style}></div>
 }

--- a/browser/src/UI/components/CursorPositioner.tsx
+++ b/browser/src/UI/components/CursorPositioner.tsx
@@ -24,6 +24,8 @@ export interface ICursorPositionerViewProps extends ICursorPositionerProps {
     containerWidth: number
     containerHeight: number
 
+    fontPixelWidth: number
+
     backgroundColor: string
 }
 
@@ -87,7 +89,7 @@ export class CursorPositionerView extends React.PureComponent<ICursorPositionerV
 
         const arrowStyleWithAdjustments = {
             ...arrowStyle,
-            left: this.props.x.toString() + "px",
+            left: (this.props.x + this.props.fontPixelWidth / 2).toString() + "px",
         }
 
         const childStyleWithAdjustments = this.state.isMeasured ? {
@@ -103,7 +105,7 @@ export class CursorPositionerView extends React.PureComponent<ICursorPositionerV
                 </div>
             </div>
             <div style={arrowStyleWithAdjustments}>
-                <Arrow direction={this.state.shouldOpenDownward ? ArrowDirection.Up : ArrowDirection.Down} size={8} color={this.props.beakColor} />
+                <Arrow direction={this.state.shouldOpenDownward ? ArrowDirection.Up : ArrowDirection.Down} size={5} color={this.props.beakColor} />
             </div>
         </div>
     }
@@ -147,6 +149,7 @@ const mapStateToProps = (state: IState, props?: ICursorPositionerProps): ICursor
 
     return {
         beakColor,
+        fontPixelWidth: state.fontPixelWidth,
         x,
         y,
         containerWidth: state.viewport.width,

--- a/browser/src/UI/components/CursorPositioner.tsx
+++ b/browser/src/UI/components/CursorPositioner.tsx
@@ -12,7 +12,11 @@ import { IState } from "./../State"
 
 import { Arrow, ArrowDirection } from "./Arrow"
 
-export interface ICursorPositionerViewProps {
+export interface ICursorPositionerProps {
+    beakColor?: string
+}
+
+export interface ICursorPositionerViewProps extends ICursorPositionerProps {
     x: number
     y: number
     lineHeight: number
@@ -99,7 +103,7 @@ export class CursorPositionerView extends React.PureComponent<ICursorPositionerV
                 </div>
             </div>
             <div style={arrowStyleWithAdjustments}>
-                <Arrow direction={this.state.shouldOpenDownward ? ArrowDirection.Up : ArrowDirection.Down} size={10} color={this.props.backgroundColor} />
+                <Arrow direction={this.state.shouldOpenDownward ? ArrowDirection.Up : ArrowDirection.Down} size={8} color={this.props.beakColor} />
             </div>
         </div>
     }
@@ -133,13 +137,16 @@ export class CursorPositionerView extends React.PureComponent<ICursorPositionerV
     }
 }
 
-const mapStateToProps = (state: IState): ICursorPositionerViewProps => {
+const mapStateToProps = (state: IState, props?: ICursorPositionerProps): ICursorPositionerViewProps => {
 
     const x = state.cursorPixelX - (state.fontPixelWidth / 2) - 2
     const y = state.cursorPixelY - (state.fontPixelHeight * 1)
     const lineHeight = state.fontPixelHeight
 
+    const beakColor = (props && props.beakColor) ? props.beakColor : state.backgroundColor
+
     return {
+        beakColor,
         x,
         y,
         containerWidth: state.viewport.width,

--- a/browser/src/UI/components/QuickInfo.tsx
+++ b/browser/src/UI/components/QuickInfo.tsx
@@ -7,6 +7,8 @@ import { IState } from "./../State"
 
 import { CursorPositioner } from "./CursorPositioner"
 
+import * as Color from "color"
+
 require("./QuickInfo.less") // tslint:disable-line no-var-requires
 
 export interface IQuickInfoProps {
@@ -24,13 +26,20 @@ export class QuickInfo extends React.PureComponent<IQuickInfoProps, void> {
             return null
         }
 
+        const backgroundColor = Color(this.props.backgroundColor)
+        const foregroundColor = Color(this.props.foregroundColor)
+
+        const borderColor = backgroundColor.luminosity() > 0.5 ? foregroundColor.lighten(0.6) : foregroundColor.darken(0.6)
+        const borderColorString = borderColor.rgb().toString()
+
         const innerCommonStyle: React.CSSProperties = {
             "opacity": this.props.visible ? 1 : 0,
             backgroundColor: this.props.backgroundColor,
+            border: `1px solid ${borderColorString}`,
             color: this.props.foregroundColor,
         }
 
-        return <CursorPositioner>
+        return <CursorPositioner beakColor={borderColorString}>
             <div key={"quickinfo-container"} className="quickinfo-container enable-mouse">
                 <div key={"quickInfo"} style={innerCommonStyle} className="quickinfo">
                     {this.props.elements}

--- a/browser/src/UI/components/QuickInfo.tsx
+++ b/browser/src/UI/components/QuickInfo.tsx
@@ -34,7 +34,7 @@ export class QuickInfo extends React.PureComponent<IQuickInfoProps, void> {
         const borderColor = backgroundColor.luminosity() > 0.5 ? foregroundColor.lighten(0.6) : foregroundColor.darken(0.6)
         const borderColorString = borderColor.rgb().toString()
 
-        const innerCommonStyle: React.CSSProperties = {
+        const quickInfoStyle: React.CSSProperties = {
             "opacity": this.props.visible ? 1 : 0,
             backgroundColor: this.props.backgroundColor,
             border: `1px solid ${borderColorString}`,
@@ -43,7 +43,7 @@ export class QuickInfo extends React.PureComponent<IQuickInfoProps, void> {
 
         return <CursorPositioner beakColor={borderColorString}>
             <div key={"quickinfo-container"} className="quickinfo-container enable-mouse">
-                <div key={"quickInfo"} style={innerCommonStyle} className="quickinfo">
+                <div key={"quickInfo"} style={quickInfoStyle} className="quickinfo">
                     {this.props.elements}
                 </div>
             </div>

--- a/browser/src/UI/components/QuickInfo.tsx
+++ b/browser/src/UI/components/QuickInfo.tsx
@@ -26,6 +26,8 @@ export class QuickInfo extends React.PureComponent<IQuickInfoProps, void> {
             return null
         }
 
+        // TODO:
+        // This should be factored out as part of colorscheme management (#412)
         const backgroundColor = Color(this.props.backgroundColor)
         const foregroundColor = Color(this.props.foregroundColor)
 

--- a/package.json
+++ b/package.json
@@ -121,6 +121,7 @@
   },
   "devDependencies": {
     "@types/classnames": "0.0.32",
+    "@types/color": "2.0.0",
     "@types/jsdom": "11.0.0",
     "@types/lodash": "4.14.38",
     "@types/minimatch": "3.0.1",
@@ -137,6 +138,7 @@
     "babili-webpack-plugin": "0.1.2",
     "bs-platform": "1.8.0",
     "classnames": "2.2.5",
+    "color": "2.0.0",
     "concurrently": "3.1.0",
     "cross-env": "3.1.3",
     "css-loader": "0.28.4",


### PR DESCRIPTION
This was inspired by @josemarluedke 's PR #789 to make the QuickInfo UX more apparent against the background. I took a try at generalizing the border for different schemes (bringing in the `color` library to help derive a border color), and also cleaned up the arrow / beak a bit.

Here's how it looks with the changes on various colorschemes:
![image](https://user-images.githubusercontent.com/13532591/31570372-f0708160-b037-11e7-8299-6ad88db343da.png)
![delek](https://user-images.githubusercontent.com/13532591/31570358-d28d3b98-b037-11e7-8957-d50f0a67b2d9.png)
![solarized dark](https://user-images.githubusercontent.com/13532591/31570359-d2a29970-b037-11e7-9bd6-132be3efe14f.png)

I also made the 'beak' smaller and added a small entrance animation, to be in sync with the QuickInfo container (which has a 0.5s entrance animation).


