### PR TITLE
Fix #436 - init.vim on Windows

### DIFF
--- a/browser/src/neovim/NeovimInstance.ts
+++ b/browser/src/neovim/NeovimInstance.ts
@@ -338,12 +338,7 @@ export class NeovimInstance extends EventEmitter implements INeovimInstance {
             return this.open(loadInitVim)
         } else {
             // Use path from: https://github.com/neovim/neovim/wiki/FAQ
-            let rootFolder
-            if (Platform.isWindows()) {
-                rootFolder = path.join(Platform.getUserHome(), "AppData", "Local", "nvim")
-            } else {
-                rootFolder = path.join(Platform.getUserHome(), ".config", "nvim")
-            }
+            const rootFolder = Platform.isWindows() ? path.join(Platform.getUserHome(), "AppData", "Local", "nvim") : path.join(Platform.getUserHome(), ".config", "nvim")
 
             mkdirp.sync(rootFolder)
             const initVimPath = path.join(rootFolder, "init.vim")

--- a/browser/src/neovim/NeovimInstance.ts
+++ b/browser/src/neovim/NeovimInstance.ts
@@ -342,7 +342,7 @@ export class NeovimInstance extends EventEmitter implements INeovimInstance {
             if (Platform.isWindows()) {
                 rootFolder = path.join(Platform.getUserHome(), "AppData", "Local", "nvim")
             } else {
-                rootFolder = "~/.config/nvim"
+                rootFolder = path.join(Platform.getUserHome(), ".config", "nvim")
             }
 
             mkdirp.sync(rootFolder)

--- a/browser/src/neovim/NeovimInstance.ts
+++ b/browser/src/neovim/NeovimInstance.ts
@@ -14,6 +14,7 @@ import { IWindow, Window } from "./Window"
 
 import * as Actions from "./../actions"
 import { measureFont } from "./../Font"
+import * as Platform from "./../Platform"
 import { PluginManager } from "./../Plugins/PluginManager"
 import { IPixelPosition, IPosition } from "./../Screen"
 import { configuration } from "./../Services/Configuration"
@@ -334,7 +335,13 @@ export class NeovimInstance extends EventEmitter implements INeovimInstance {
         if (typeof(loadInitVim) === "string") {
             return this.open(loadInitVim)
         } else {
-            return this.open("$MYVIMRC")
+            // Use path from: https://github.com/neovim/neovim/wiki/FAQ
+            if (Platform.isWindows()) {
+                const initVimPath = path.join(Platform.getUserHome(), "AppData", "Local", "nvim", "init.vim")
+                return this.open(initVimPath)
+            } else {
+                return this.open("~/.config/nvim/init.vim")
+            }
         }
     }
 

--- a/browser/src/neovim/NeovimInstance.ts
+++ b/browser/src/neovim/NeovimInstance.ts
@@ -2,6 +2,8 @@ import { remote } from "electron"
 import { EventEmitter } from "events"
 import * as path from "path"
 
+import * as mkdirp from "mkdirp"
+
 import { Event, IEvent } from "./../Event"
 import * as Log from "./../Log"
 
@@ -336,12 +338,17 @@ export class NeovimInstance extends EventEmitter implements INeovimInstance {
             return this.open(loadInitVim)
         } else {
             // Use path from: https://github.com/neovim/neovim/wiki/FAQ
+            let rootFolder
             if (Platform.isWindows()) {
-                const initVimPath = path.join(Platform.getUserHome(), "AppData", "Local", "nvim", "init.vim")
-                return this.open(initVimPath)
+                rootFolder = path.join(Platform.getUserHome(), "AppData", "Local", "nvim")
             } else {
-                return this.open("~/.config/nvim/init.vim")
+                rootFolder = "~/.config/nvim"
             }
+
+            mkdirp.sync(rootFolder)
+            const initVimPath = path.join(rootFolder, "init.vim")
+
+            return this.open(initVimPath)
         }
     }
 


### PR DESCRIPTION
This builds on the PR @CrossR put together for custom init.vim paths (#784).

Instead of editing `$MYVIMRC` which seems to have inconsistent results on all platform, I baked in the paths based on the Neovim documentation. This should give more reliable behavior. I also create the directory if it hasn't been created yet.