### PR TITLE
Fix ScrollOff Issue.

### DIFF
--- a/vim/core/oni-core-interop/plugin/init.vim
+++ b/vim/core/oni-core-interop/plugin/init.vim
@@ -139,7 +139,9 @@ function OniUpdateWindowDisplayMap(shouldMeasure)
     while(cursor <= windowEndLine)
         call setpos(".", [bufNum, cursor, 0])
         let cursorString = string(cursor)
-        let mapping[cursorString] = winline()
+        let newPos = getpos(".")
+        let newLine = newPos[1]
+        let mapping[cursorString] = newLine
         let cursor = cursor+1
     endwhile
 


### PR DESCRIPTION
There looks to be some form of odd issue with using `winline()` in the Oni interop plugin for the Window  display map.
It causes some very odd scrolling, as outlined in #395.

Updating it to get the current pos and use that line instead seems to work fine, but there may be a better way of doing it. 

This change brings the experience inline with NVIM-QT, at least as far as I can tell.
Anyone who uses scrolloff more than me should probably test this.