### PR TITLE
0.2.13: Fix regression in QuickOpen in installed builds

### DIFF
--- a/browser/src/Services/QuickOpen/RipGrep.ts
+++ b/browser/src/Services/QuickOpen/RipGrep.ts
@@ -11,7 +11,9 @@ import * as Platform from "./../../Platform"
 export const getCommand = () => {
     const rootPath = path.join(__dirname, "node_modules", "vscode-ripgrep", "bin")
     const executableName = Platform.isWindows() ? "rg.exe" : "rg"
-    return path.join(rootPath, executableName)
+
+    // Wrap in quotes in case there are spaces in the path
+    return "\"" + path.join(rootPath, executableName) + "\""
 }
 
 export const getArguments = (excludePaths: string[]) => {


### PR DESCRIPTION
__Issue:__ The path for executing RipGrep isn't wrapped in quotes. This causes problems if the path has spaces, and will happen when installed to the default windows folder (`C:\Program Files (x86)`).

__Fix:__ Wrap RipGrep executable path in quotes to account for spaces