### PR TITLE
API: Add onBufferSaved event

### DIFF
--- a/browser/src/Editor/NeovimEditor.tsx
+++ b/browser/src/Editor/NeovimEditor.tsx
@@ -64,6 +64,7 @@ export class NeovimEditor implements IEditor {
     private _onBufferEnterEvent = new Event<Oni.EditorBufferEventArgs>()
     private _onBufferLeaveEvent = new Event<Oni.EditorBufferEventArgs>()
     private _onBufferChangedEvent = new Event<Oni.EditorBufferChangedEventArgs>()
+    private _onBufferSavedEvent = new Event<Oni.EditorBufferEventArgs>()
 
     private _hasLoaded: boolean = false
 
@@ -98,6 +99,10 @@ export class NeovimEditor implements IEditor {
 
     public get onBufferChanged(): IEvent<Oni.EditorBufferChangedEventArgs> {
         return this._onBufferChangedEvent
+    }
+
+    public get onBufferSaved(): IEvent<Oni.EditorBufferEventArgs> {
+        return this._onBufferSavedEvent
     }
 
     // Capabilities
@@ -363,6 +368,11 @@ export class NeovimEditor implements IEditor {
         } else if (eventName === "BufWritePost") {
             // After we save we aren't modified... but we can pass it in just to be safe
             UI.Actions.bufferSave(evt.bufferNumber, evt.modified, evt.version)
+
+            this._onBufferSavedEvent.dispatch({
+                filePath: evt.bufferFullPath,
+                language: evt.filetype,
+            })
         } else if (eventName === "BufDelete") {
 
             this._neovimInstance.getBufferIds()

--- a/browser/src/Services/EditorManager.ts
+++ b/browser/src/Services/EditorManager.ts
@@ -60,6 +60,8 @@ class AllEditors implements Oni.Editor {
     private _onBufferEnter = new Event<Oni.EditorBufferEventArgs>()
     private _onBufferLeave = new Event<Oni.EditorBufferEventArgs>()
     private _onBufferChanged = new Event<Oni.EditorBufferChangedEventArgs>()
+    private _onBufferSaved = new Event<Oni.EditorBufferEventArgs>()
+
     /**
      * API Methods
      */
@@ -105,6 +107,10 @@ class AllEditors implements Oni.Editor {
         return this._onBufferLeave
     }
 
+    public get onBufferSaved(): IEvent<Oni.EditorBufferEventArgs> {
+        return this._onBufferSaved
+    }
+
     /**
      * Internal methods
      */
@@ -117,6 +123,7 @@ class AllEditors implements Oni.Editor {
         this._subscriptions.push(newEditor.onBufferEnter.subscribe((val) => this._onBufferEnter.dispatch(val)))
         this._subscriptions.push(newEditor.onBufferLeave.subscribe((val) => this._onBufferLeave.dispatch(val)))
         this._subscriptions.push(newEditor.onBufferChanged.subscribe((val) => this._onBufferChanged.dispatch(val)))
+        this._subscriptions.push(newEditor.onBufferSaved.subscribe((val) => this._onBufferSaved.dispatch(val)))
     }
 
     public getUnderlyingEditor(): Oni.Editor {

--- a/definitions/Oni.d.ts
+++ b/definitions/Oni.d.ts
@@ -66,6 +66,7 @@ declare namespace Oni {
         onBufferEnter: IEvent<EditorBufferEventArgs>
         onBufferLeave: IEvent<EditorBufferEventArgs>
         onBufferChanged: IEvent<EditorBufferChangedEventArgs>
+        onBufferSaved: IEvent<EditorBufferEventArgs>
 
         // Optional capabilities for the editor to implement
         neovim?: NeovimEditorCapability


### PR DESCRIPTION
Adds an `onBufferSaved` event off the `Oni.Editor` API - ie:
 ```
oni.editors.activeEditor.onBufferSaved.subscribe((bufferInfo) => console.dir(bufferInfo))`
```