### PR TITLE
UX: Autocompletion styling

### DIFF
--- a/browser/src/UI/components/Arrow.less
+++ b/browser/src/UI/components/Arrow.less
@@ -6,6 +6,14 @@
     opacity: 0;
     animation-fill-mode: forwards;
 
+    &.right {
+        animation-name: appear-right;
+    }
+
+    &.left {
+        animation-name: appear-left;
+    }
+
     &.down {
         animation-name: appear-down;
     }
@@ -22,4 +30,12 @@
 @keyframes appear-up {
     from {transform: translateY(4px); opacity: 0;}
     to {transform: translateY(0px);opacity: 1;}
+}
+@keyframes appear-left {
+    from {transform: translateX(4px); opacity: 0;}
+    to {transform: translateX(0px);opacity: 1;}
+}
+@keyframes appear-right {
+    from {transform: translateX(-4px); opacity: 0;}
+    to {transform: translateX(0px);opacity: 1;}
 }

--- a/browser/src/UI/components/Arrow.tsx
+++ b/browser/src/UI/components/Arrow.tsx
@@ -10,7 +10,9 @@ import * as React from "react"
 
 export enum ArrowDirection {
     Up = 0,
-    Down,
+    Down = 1,
+    Left = 2,
+    Right = 3,
 }
 
 export interface IArrowProps {
@@ -40,9 +42,38 @@ export const Arrow = (props: IArrowProps): JSX.Element => {
         borderTop: solidBorder,
     }
 
-    const isUp = props.direction === ArrowDirection.Up
-    const style = isUp ? upArrowStyle : downArrowStyle
-    const className = isUp ? "arrow up" : "arrow down"
+    const leftArrowStyle = {
+        width: "0px",
+        height: "0px",
+        borderTop: transparentBorder,
+        borderRight: solidBorder,
+        borderBottom: transparentBorder,
+    }
+
+    const rightArrowStyle = {
+        width: "0px",
+        height: "0px",
+        borderTop: transparentBorder,
+        borderLeft: solidBorder,
+        borderBottom: transparentBorder,
+    }
+
+    let style: any = upArrowStyle
+    let className = "arrow"
+
+    if (props.direction === ArrowDirection.Down) {
+        style = downArrowStyle
+        className = "arrow down"
+    } else if(props.direction === ArrowDirection.Up) {
+        style = upArrowStyle
+        className = "arrow up"
+    } else if(props.direction === ArrowDirection.Left) {
+        style = leftArrowStyle
+        className = "arrow left"
+    } else if(props.direction === ArrowDirection.Right) {
+        style = rightArrowStyle
+        className = "arrow right"
+    }
 
     return <div className={className} style={style}></div>
 }

--- a/browser/src/UI/components/Arrow.tsx
+++ b/browser/src/UI/components/Arrow.tsx
@@ -64,13 +64,13 @@ export const Arrow = (props: IArrowProps): JSX.Element => {
     if (props.direction === ArrowDirection.Down) {
         style = downArrowStyle
         className = "arrow down"
-    } else if(props.direction === ArrowDirection.Up) {
+    } else if (props.direction === ArrowDirection.Up) {
         style = upArrowStyle
         className = "arrow up"
-    } else if(props.direction === ArrowDirection.Left) {
+    } else if (props.direction === ArrowDirection.Left) {
         style = leftArrowStyle
         className = "arrow left"
-    } else if(props.direction === ArrowDirection.Right) {
+    } else if (props.direction === ArrowDirection.Right) {
         style = rightArrowStyle
         className = "arrow right"
     }

--- a/browser/src/UI/components/AutoCompletion.less
+++ b/browser/src/UI/components/AutoCompletion.less
@@ -5,18 +5,16 @@
     .layer;
 
     .box-shadow;
-
-    background-color: @background-color;
-    color: @text-color;
     width: 600px;
     overflow: hidden;
     animation-name: appear;
     animation-duration: 0.1s;
 
+    margin-top: -8px;
+
     .entry {
         &.selected {
             .box-shadow;
-            background-color: rgb(60, 60, 60);
 
             .main {
                 opacity: 1;
@@ -36,15 +34,12 @@
 
             .icon {
                 padding: 4px;
-                width: 20px;
+                width: 1.2em;
                 flex: 0 0 auto;
-                color: white;
                 text-align: center;
 
                 i {
-                    margin-left: 4px;
-                    margin-right: 4px;
-                    font-size: 10px;
+                    font-size: 0.9em;
                 }
             }
         }
@@ -55,8 +50,8 @@
             margin-left: 8px;
 
             .highlight {
-                font-weight: bold;
-                color: @text-color-highlight;
+                // font-weight: bold;
+                text-decoration: underline;
             }
         }
 
@@ -70,9 +65,8 @@
             white-space: nowrap;
             margin-left: 16px;
 
-            color: @text-color-detail;
-
-            font-size: 11px;
+            font-size: 0.8em;
+            opacity: 0.8;
             visibility: hidden;
         }
     }
@@ -80,10 +74,9 @@
     .documentation {
         .box-shadow-inset;
         padding: 8px;
-        font-size: 10px;
+        font-size: 0.8em;
         max-height: 48px;
         overflow-y: auto;
-        color: @text-color-dark;
     }
 }
 

--- a/browser/src/UI/components/AutoCompletion.tsx
+++ b/browser/src/UI/components/AutoCompletion.tsx
@@ -12,6 +12,7 @@ import * as Colors from "./../Colors"
 import { Icon } from "./../Icon"
 import { IState /*, AutoCompletionInfo */ } from "./../State"
 
+import { Arrow, ArrowDirection } from "./Arrow"
 import { CursorPositioner, OpenDirection } from "./CursorPositioner"
 import { HighlightText } from "./HighlightText"
 
@@ -20,6 +21,8 @@ export interface IAutoCompletionProps {
     base: string
     entries: Oni.Plugin.CompletionInfo[]
     selectedIndex: number
+
+    fontWidthInPixels: number
 
     backgroundColor: string
     foregroundColor: string
@@ -39,8 +42,9 @@ export class AutoCompletion extends React.PureComponent<IAutoCompletionProps, vo
 
         const containerStyle: React.CSSProperties = {
             backgroundColor: this.props.backgroundColor,
-            foregroundColor: this.props.foregroundColor,
+            color: this.props.foregroundColor,
             border: "1px solid " + highlightColor,
+            marginLeft: (-3 * this.props.fontWidthInPixels) + "px",
         }
 
         if (this.props.entries.length === 0) {
@@ -55,7 +59,6 @@ export class AutoCompletion extends React.PureComponent<IAutoCompletionProps, vo
         // TODO: sync max display items (10) with value in Reducer.autoCompletionReducer() (Reducer.ts)
         const firstTenEntries = take(this.props.entries, 10)
 
-
         const entries = firstTenEntries.map((s, i) => {
             const isSelected = i === this.props.selectedIndex
 
@@ -64,8 +67,7 @@ export class AutoCompletion extends React.PureComponent<IAutoCompletionProps, vo
 
         const selectedItemDocumentation = getDocumentationFromItems(firstTenEntries, this.props.selectedIndex)
 
-        return (<CursorPositioner beakColor={highlightColor} openDirection={OpenDirection.Down}>
-
+        return (<CursorPositioner beakColor={highlightColor} openDirection={OpenDirection.Down} hideArrow={true}>
                 <div style={containerStyle} className="autocompletion enable-mouse">
                     <div className="entries">
                         {entries}
@@ -108,11 +110,14 @@ export class AutoCompletionItem extends React.PureComponent<IAutoCompletionItemP
             backgroundColor: highlightColor,
         }
 
+        const arrowColor = this.props.isSelected ? highlightColor : "transparent"
+
         return <div className={className}>
             <div className="main">
                 <span className="icon" style={iconContainerStyle}>
                     <AutoCompletionIcon kind={this.props.kind as any /* FIXME: undefined */} />
                 </span>
+                <Arrow direction={ArrowDirection.Right} size={5}  color={arrowColor}/>
                 <HighlightText className="label" highlightClassName="highlight" highlightText={this.props.base} text={this.props.label} />
                 <span className="detail">{this.props.detail}</span>
             </div>
@@ -187,6 +192,7 @@ const mapStateToProps = (state: IState) => {
             selectedIndex: 0,
             backgroundColor: "",
             foregroundColor: "",
+            fontWidthInPixels: 0,
         }
     } else {
         const ret: IAutoCompletionProps = {
@@ -196,6 +202,7 @@ const mapStateToProps = (state: IState) => {
             selectedIndex: state.autoCompletion.selectedIndex,
             foregroundColor: state.foregroundColor,
             backgroundColor: state.backgroundColor,
+            fontWidthInPixels: state.fontPixelWidth,
         }
         return ret
     }

--- a/browser/src/UI/components/AutoCompletion.tsx
+++ b/browser/src/UI/components/AutoCompletion.tsx
@@ -8,17 +8,21 @@ import * as types from "vscode-languageserver-types"
 
 import { connect } from "react-redux"
 
+import * as Colors from "./../Colors"
 import { Icon } from "./../Icon"
 import { IState /*, AutoCompletionInfo */ } from "./../State"
+
+import { CursorPositioner, OpenDirection } from "./CursorPositioner"
 import { HighlightText } from "./HighlightText"
 
 export interface IAutoCompletionProps {
     visible: boolean
-    x: number
-    y: number
     base: string
     entries: Oni.Plugin.CompletionInfo[]
     selectedIndex: number
+
+    backgroundColor: string
+    foregroundColor: string
 }
 
 require("./AutoCompletion.less") // tslint:disable-line no-var-requires
@@ -31,10 +35,12 @@ export class AutoCompletion extends React.PureComponent<IAutoCompletionProps, vo
             return null
         }
 
+        const highlightColor = Colors.getBorderColor(this.props.backgroundColor, this.props.foregroundColor)
+
         const containerStyle: React.CSSProperties = {
-            position: "absolute",
-            top: this.props.y.toString() + "px",
-            left: this.props.x.toString() + "px",
+            backgroundColor: this.props.backgroundColor,
+            foregroundColor: this.props.foregroundColor,
+            border: "1px solid " + highlightColor,
         }
 
         if (this.props.entries.length === 0) {
@@ -49,20 +55,24 @@ export class AutoCompletion extends React.PureComponent<IAutoCompletionProps, vo
         // TODO: sync max display items (10) with value in Reducer.autoCompletionReducer() (Reducer.ts)
         const firstTenEntries = take(this.props.entries, 10)
 
+
         const entries = firstTenEntries.map((s, i) => {
             const isSelected = i === this.props.selectedIndex
 
-            return <AutoCompletionItem {...s} isSelected={isSelected} base={this.props.base} />
+            return <AutoCompletionItem {...s} isSelected={isSelected} base={this.props.base} highlightColor={highlightColor}/>
         })
 
         const selectedItemDocumentation = getDocumentationFromItems(firstTenEntries, this.props.selectedIndex)
 
-        return (<div style={containerStyle} className="autocompletion enable-mouse">
-            <div className="entries">
-                {entries}
-            </div>
-            <AutoCompletionDocumentation documentation={selectedItemDocumentation} />
-        </div>)
+        return (<CursorPositioner beakColor={highlightColor} openDirection={OpenDirection.Down}>
+
+                <div style={containerStyle} className="autocompletion enable-mouse">
+                    <div className="entries">
+                        {entries}
+                    </div>
+                    <AutoCompletionDocumentation documentation={selectedItemDocumentation} />
+                </div>
+               </CursorPositioner>)
     }
 }
 
@@ -81,6 +91,7 @@ const getDocumentationFromItems = (items: Oni.Plugin.CompletionInfo[], selectedI
 export interface IAutoCompletionItemProps extends Oni.Plugin.CompletionInfo {
     base: string
     isSelected: boolean
+    highlightColor?: string
 }
 
 export class AutoCompletionItem extends React.PureComponent<IAutoCompletionItemProps, void> {
@@ -171,20 +182,20 @@ const mapStateToProps = (state: IState) => {
     if (!state.autoCompletion) {
         return {
             visible: false,
-            x: state.cursorPixelX,
-            y: state.cursorPixelY + state.fontPixelHeight,
             base: "",
             entries: EmptyArray,
             selectedIndex: 0,
+            backgroundColor: "",
+            foregroundColor: "",
         }
     } else {
         const ret: IAutoCompletionProps = {
             visible: true,
-            x: state.cursorPixelX,
-            y: state.cursorPixelY + state.fontPixelHeight,
             base: state.autoCompletion.base,
             entries: state.autoCompletion.entries,
             selectedIndex: state.autoCompletion.selectedIndex,
+            foregroundColor: state.foregroundColor,
+            backgroundColor: state.backgroundColor,
         }
         return ret
     }

--- a/browser/src/UI/components/CursorPositioner.tsx
+++ b/browser/src/UI/components/CursorPositioner.tsx
@@ -12,8 +12,14 @@ import { IState } from "./../State"
 
 import { Arrow, ArrowDirection } from "./Arrow"
 
+export enum OpenDirection {
+    Up = 1,
+    Down = 2,
+}
+
 export interface ICursorPositionerProps {
     beakColor?: string
+    openDirection?: OpenDirection
 }
 
 export interface ICursorPositionerViewProps extends ICursorPositionerProps {
@@ -64,7 +70,7 @@ export class CursorPositionerView extends React.PureComponent<ICursorPositionerV
 
     public render(): JSX.Element {
         const adjustedX = this.state.adjustedX
-        const adjustedY = this.state.shouldOpenDownward ? this.props.y + this.props.lineHeight * 3 : this.props.y
+        const adjustedY = this.state.shouldOpenDownward ? this.props.y + this.props.lineHeight * 2.5 : this.props.y
 
         const containerStyle: React.CSSProperties = {
             position: "absolute",
@@ -114,8 +120,15 @@ export class CursorPositionerView extends React.PureComponent<ICursorPositionerV
         if (element) {
             const rect = element.getBoundingClientRect()
 
+            const margin = this.props.lineHeight * 2
+            const canOpenUpward = this.props.y - rect.height > margin
+            const bottomScreenPadding = 50
+            const canOpenDownard = this.props.y + rect.height + this.props.lineHeight * 3 < this.props.containerHeight - margin - bottomScreenPadding
+
             if (!this.state.isMeasured) {
-                const shouldOpenDownward = this.props.y - rect.height < this.props.lineHeight * 2
+
+
+                const shouldOpenDownward = (this.props.openDirection !== OpenDirection.Down && !canOpenUpward) || (this.props.openDirection === OpenDirection.Down && canOpenDownard)
 
                 const rightBounds = this.props.x + rect.width
 

--- a/browser/src/UI/components/CursorPositioner.tsx
+++ b/browser/src/UI/components/CursorPositioner.tsx
@@ -20,6 +20,7 @@ export enum OpenDirection {
 export interface ICursorPositionerProps {
     beakColor?: string
     openDirection?: OpenDirection
+    hideArrow?: boolean
 }
 
 export interface ICursorPositionerViewProps extends ICursorPositionerProps {
@@ -96,6 +97,7 @@ export class CursorPositionerView extends React.PureComponent<ICursorPositionerV
         const arrowStyleWithAdjustments = {
             ...arrowStyle,
             left: (this.props.x + this.props.fontPixelWidth / 2).toString() + "px",
+            visibility: this.props.hideArrow ? "hidden" : "visible",
         }
 
         const childStyleWithAdjustments = this.state.isMeasured ? {

--- a/browser/src/UI/components/CursorPositioner.tsx
+++ b/browser/src/UI/components/CursorPositioner.tsx
@@ -128,8 +128,6 @@ export class CursorPositionerView extends React.PureComponent<ICursorPositionerV
             const canOpenDownard = this.props.y + rect.height + this.props.lineHeight * 3 < this.props.containerHeight - margin - bottomScreenPadding
 
             if (!this.state.isMeasured) {
-
-
                 const shouldOpenDownward = (this.props.openDirection !== OpenDirection.Down && !canOpenUpward) || (this.props.openDirection === OpenDirection.Down && canOpenDownard)
 
                 const rightBounds = this.props.x + rect.width


### PR DESCRIPTION
These are some tweaks to autocompletion, to make it more consistent with the work done for the Menu, QuickInfo, and Signature help - this leverages the foreground / background colors, so that it doesn't look so out of place:

![image](https://user-images.githubusercontent.com/13532591/31749002-01f8cb48-b42c-11e7-9142-92b6ce9bc251.png)

And it meshes better with other color schemes:
![image](https://user-images.githubusercontent.com/13532591/31749015-1bb38ece-b42c-11e7-8983-5dbcace29e07.png)

