### PR TITLE
Added optional task for adding Oni to right click menu on Windows

### DIFF
--- a/build/BuildSetupTemplate.js
+++ b/build/BuildSetupTemplate.js
@@ -42,7 +42,12 @@ const fileExtensions = {
 }
 
 const addToEnv = `
-Root: HKCU; Subkey: "Environment"; ValueType: expandsz; ValueName: "Path"; ValueData: "{olddata};{app}"; Tasks: addtopath; Check: NeedsAddPath(ExpandConstant('{app}'))`
+Root: HKCU; Subkey: "Environment"; ValueType: expandsz; ValueName: "Path"; ValueData: "{olddata};{app}"; Tasks: addtopath; Check: NeedsAddPath(ExpandConstant('{app}'))
+
+Root: HKCU; Subkey: "SOFTWARE\\Classes\\*\\shell\\${prodName}"; ValueType: expandsz; ValueName: ""; ValueData: "Open with ${prodName}"; Tasks: addToRightClickMenu; Flags: uninsdeletekey
+Root: HKCU; Subkey: "SOFTWARE\\Classes\\*\\shell\\${prodName}"; ValueType: expandsz; ValueName: "Icon"; ValueData: "{app}\\resources\\app\\images\\oni.ico"; Tasks: addToRightClickMenu
+Root: HKCU; Subkey: "SOFTWARE\\Classes\\*\\shell\\${prodName}\\command"; ValueType: expandsz; ValueName: ""; ValueData: """{app}\\${prodName}.exe"" ""%1"""; Tasks: addToRightClickMenu
+`
 
 function getFileRegKey(ext, desc) {
 

--- a/build/setup.template.iss
+++ b/build/setup.template.iss
@@ -26,7 +26,7 @@ Source: "{{SourcePath}}"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs
 
 [Tasks]
 Name: "addtopath"; Description: "Add {{AppName}} to %PATH%"; GroupDescription: "Other"
-Name: "registerAsEditor"; Description: "Register {{AppName}} as an editor"; GroupDescription: "Other"
+Name: "registerAsEditor"; Description: "Register {{AppName}} as an editor for all supported file types."; GroupDescription: "Other"
 Name: "addToRightClickMenu"; Description: "Add {{AppName}} to the right click menu for all files."; GroupDescription: "Other"
 
 [Icons]

--- a/build/setup.template.iss
+++ b/build/setup.template.iss
@@ -27,6 +27,7 @@ Source: "{{SourcePath}}"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs
 [Tasks]
 Name: "addtopath"; Description: "Add {{AppName}} to %PATH%"; GroupDescription: "Other"
 Name: "registerAsEditor"; Description: "Register {{AppName}} as an editor"; GroupDescription: "Other"
+Name: "addToRightClickMenu"; Description: "Add {{AppName}} to the right click menu for all files."; GroupDescription: "Other"
 
 [Icons]
 Name: "{group}\{{AppName}}"; Filename: "{app}\{{AppExecutableName}}"


### PR DESCRIPTION
Updated the Windows Registry keys so that optionally Oni can be used from the right click menu for all files. 

Currently, I've only added the registry keys for opening a file, so you can right click any file and there will be an option to open it with Oni. 

We could look at also adding registry keys for opening a folder? I think code does this.
Then you would be able to Right click and open a folder with Oni and it would default the current directory to that folder.

Fixes the Windows portion of #820.