### PR TITLE
Fix #822: Improved OSX defaults for QuickOpen and Command Palette

### DIFF
--- a/browser/src/Input/KeyBindings.ts
+++ b/browser/src/Input/KeyBindings.ts
@@ -8,7 +8,6 @@ import * as Platform from "./../Platform"
 import { Configuration } from "./../Services/Configuration"
 
 export const applyDefaultKeyBindings = (oni: Oni.Plugin.Api, config: Configuration): void => {
-
     const { editors, input } = oni
 
     input.unbindAll()
@@ -18,31 +17,35 @@ export const applyDefaultKeyBindings = (oni: Oni.Plugin.Api, config: Configurati
     const isInsertOrCommandMode = () => editors.activeEditor.mode === "insert" || editors.activeEditor.mode === "cmdline_normal"
 
     if (Platform.isMac()) {
-        input.bind("<M-q>", "oni.quit")
+        input.bind("<m-q>", "oni.quit")
+        input.bind("<m-p>", "quickOpen.show")
+        input.bind("<m-s-p>", "commands.show")
 
         if (config.getValue("editor.clipboard.enabled")) {
-            input.bind("<M-c>", "editor.clipboard.yank", isVisualMode)
-            input.bind("<M-v>", "editor.clipboard.paste", isInsertOrCommandMode)
+            input.bind("<m-c>", "editor.clipboard.yank", isVisualMode)
+            input.bind("<m-v>", "editor.clipboard.paste", isInsertOrCommandMode)
         }
     } else {
+        input.bind("<a-f4>", "oni.quit")
+        input.bind("<c-p>", "quickOpen.show", isNormalMode)
+        input.bind("<s-c-p>", "commands.show", isNormalMode)
+
         if (config.getValue("editor.clipboard.enabled")) {
-            input.bind("<C-c>", "editor.clipboard.yank", isVisualMode)
-            input.bind("<C-v>", "editor.clipboard.paste", isInsertOrCommandMode)
+            input.bind("<c-c>", "editor.clipboard.yank", isVisualMode)
+            input.bind("<c-v>", "editor.clipboard.paste", isInsertOrCommandMode)
         }
     }
 
     input.bind("<f3>", "language.formatter.formatDocument")
     input.bind("<f12>", "oni.editor.gotoDefinition")
-    input.bind("<S-C-P>", "commands.show", isNormalMode)
-    input.bind("<C-pageup>", "oni.process.cyclePrevious")
-    input.bind("<C-pagedown>", "oni.process.cycleNext")
+    input.bind("<c-pageup>", "oni.process.cyclePrevious")
+    input.bind("<c-pagedown>", "oni.process.cycleNext")
 
     // QuickOpen
-    input.bind("<C-p>", "quickOpen.show", isNormalMode)
-    input.bind("<C-/>", "quickOpen.showBufferLines", isNormalMode)
-    input.bind("<C-v>", "quickOpen.openFileVertical")
-    input.bind("<C-s>", "quickOpen.openFileHorizontal")
-    input.bind("<C-t>", "quickOpen.openFileNewTab")
+    input.bind("<c-/>", "quickOpen.showBufferLines", isNormalMode)
+    input.bind("<c-v>", "quickOpen.openFileVertical")
+    input.bind("<c-s>", "quickOpen.openFileHorizontal")
+    input.bind("<c-t>", "quickOpen.openFileNewTab")
 
     // Completion
     input.bind(["<enter>", "<tab>"], "completion.complete")

--- a/browser/src/Input/KeyBindings.ts
+++ b/browser/src/Input/KeyBindings.ts
@@ -8,13 +8,15 @@ import * as Platform from "./../Platform"
 import { Configuration } from "./../Services/Configuration"
 
 export const applyDefaultKeyBindings = (oni: Oni.Plugin.Api, config: Configuration): void => {
-    const { editors, input } = oni
+    const { editors, input, menu } = oni
 
     input.unbindAll()
 
     const isVisualMode = () => editors.activeEditor.mode === "visual"
     const isNormalMode = () => editors.activeEditor.mode === "normal"
     const isInsertOrCommandMode = () => editors.activeEditor.mode === "insert" || editors.activeEditor.mode === "cmdline_normal"
+
+    const isMenuOpen = () => menu.isMenuOpen()
 
     if (Platform.isMac()) {
         input.bind("<m-q>", "oni.quit")
@@ -27,7 +29,7 @@ export const applyDefaultKeyBindings = (oni: Oni.Plugin.Api, config: Configurati
         }
     } else {
         input.bind("<a-f4>", "oni.quit")
-        input.bind("<c-p>", "quickOpen.show", isNormalMode)
+        input.bind("<c-p>", "quickOpen.show", () => isNormalMode() && !isMenuOpen())
         input.bind("<s-c-p>", "commands.show", isNormalMode)
 
         if (config.getValue("editor.clipboard.enabled")) {

--- a/browser/src/Input/Keyboard/Resolvers.ts
+++ b/browser/src/Input/Keyboard/Resolvers.ts
@@ -57,6 +57,8 @@ export const createMetaKeyResolver = (keyMap: IKeyMap) => {
             mappedKey = "lt"
         }
 
+        const metaPressed = evt.metaKey
+
         let controlPressed = false
         // On Windows, when the AltGr key is pressed, _both_
         // the evt.ctrlKey and evt.altKey are set to true.
@@ -66,7 +68,7 @@ export const createMetaKeyResolver = (keyMap: IKeyMap) => {
             evt.preventDefault()
         }
 
-        if (evt.shiftKey && (!isCharacterFromShiftKey || controlPressed)) {
+        if (evt.shiftKey && (!isCharacterFromShiftKey || controlPressed || metaPressed)) {
             mappedKey = "s-" + mappedKey
         }
 
@@ -75,7 +77,7 @@ export const createMetaKeyResolver = (keyMap: IKeyMap) => {
             evt.preventDefault()
         }
 
-        if (evt.metaKey) {
+        if (metaPressed) {
             mappedKey = "m-" + mappedKey
             evt.preventDefault()
         }

--- a/definitions/Oni.d.ts
+++ b/definitions/Oni.d.ts
@@ -265,6 +265,7 @@ declare namespace Oni {
             diagnostics: Diagnostics.Api
             editors: EditorManager
             input: InputManager
+            menu: any; // TODO: Add typing for this
             process: Process
             statusBar: StatusBar
             workspace: Workspace


### PR DESCRIPTION
__Issue:__ Most editors on OS X (like VSCode, Sublime, Atom), use `<Command+P>` for file finder and `<Command+Shift+P>` for the command palette. Oni uses the same defaults as Windows, `<Control+P>` and `<Control+Shift+P>`, which is not very intuitive, and has the other downside that `<Control+P>` is double-booked as both previous entry and opening the menu.

__Fix:__ Change the defaults on OS X to use `<Command+P>` and `<Command+Shift+P>`. In addition, there was a bug where keys weren't resolved properly if `Command` and `Shift` were both pressed, so that was fixed to unblock the scenario.