### PR TITLE
Make tabs scale vertically with font size

### DIFF
--- a/browser/src/UI/components/Tabs.less
+++ b/browser/src/UI/components/Tabs.less
@@ -27,8 +27,8 @@
     align-items: flex-end;
 
     width: 100%;
-    max-height: 48px;
-    min-height: 32px;
+    max-height: 3em;
+    min-height: 2em;
     color: #c8c8c8;
     background-color: rgba(0, 0, 0, 0.2);
     overflow-x: auto;
@@ -41,7 +41,7 @@
     justify-content: center;
     cursor: pointer;
 
-    height: 32px;
+    height: 2em;
     flex: 0 0 auto;
 
     max-width: 350px;


### PR DESCRIPTION
A partial fix for https://github.com/bryphe/oni/issues/783

As far as I tested looks pretty similar to the previous configuration except that it can handle better bigger font sizes now.

The only reason I say this is a partial fix is because the css for hiding and truncating overflow of text for the tabs is not working for me, even after adding `white-space: nowrap` rule. I'd like to address this issue before marking #783 as fixed.