### PR TITLE
Adjust statusbar height scaling

### DIFF
--- a/browser/src/UI/components/StatusBar.less
+++ b/browser/src/UI/components/StatusBar.less
@@ -5,7 +5,7 @@
 
     color: @text-color;
     background-color: @background-color;
-    height: 2.8em;
+    height: 2em;
     position: relative;
     width: 100%;
 


### PR DESCRIPTION
The previous height was too big for my taste, see how it looked like previously:

![screenshot from 2017-10-24 22-39-58](https://user-images.githubusercontent.com/347552/31974888-b2552506-b90c-11e7-99ab-d029ce0953d2.png)

See it with the adjust:

![screenshot from 2017-10-24 22-39-42](https://user-images.githubusercontent.com/347552/31974875-9fae900e-b90c-11e7-8997-6665d81ad183.png)

If this is not acceptable, please let me know if we can make this configurable.
