### PR TITLE
Fix #825 - Implement `editor.quickOpen.caseSensitive` setting

### DIFF
--- a/browser/src/Services/Configuration/DefaultConfiguration.ts
+++ b/browser/src/Services/Configuration/DefaultConfiguration.ts
@@ -59,7 +59,6 @@ const BaseConfiguration: IConfigurationValues = {
     "editor.linePadding": 2,
 
     "editor.quickOpen.execCommand": null,
-    "editor.quickOpen.caseSensitive": "smart",
 
     "editor.scrollBar.visible": true,
 
@@ -73,6 +72,8 @@ const BaseConfiguration: IConfigurationValues = {
     "editor.cursorColumnOpacity": 0.1,
 
     "environment.additionalPaths": [],
+
+    "menu.caseSensitive": "smart",
 
     "recorder.copyScreenshotToClipboard": false,
     "recorder.outputPath": os.tmpdir(),

--- a/browser/src/Services/Configuration/DefaultConfiguration.ts
+++ b/browser/src/Services/Configuration/DefaultConfiguration.ts
@@ -59,6 +59,7 @@ const BaseConfiguration: IConfigurationValues = {
     "editor.linePadding": 2,
 
     "editor.quickOpen.execCommand": null,
+    "editor.quickOpen.caseSensitive": "smart",
 
     "editor.scrollBar.visible": true,
 

--- a/browser/src/Services/Configuration/IConfigurationValues.ts
+++ b/browser/src/Services/Configuration/IConfigurationValues.ts
@@ -112,13 +112,6 @@ export interface IConfigurationValues {
     // "editor.quickOpen.execCommand": "dir /s /b"
     "editor.quickOpen.execCommand": string | null
 
-    // Case-sensitivity strategy for quick-open filtering:
-    // - if `true`, is case sensitive
-    // - if `false`, is not case sensitive
-    // - if `'smart'`, is case sensitive if the query string
-    //   contains uppercase characters
-    "editor.quickOpen.caseSensitive": string | boolean
-
     "editor.fullScreenOnStart": boolean
     "editor.maximizeScreenOnStart": boolean
 
@@ -127,6 +120,13 @@ export interface IConfigurationValues {
 
     "editor.cursorColumn": boolean
     "editor.cursorColumnOpacity": number
+
+    // Case-sensitivity strategy for menu filtering:
+    // - if `true`, is case sensitive
+    // - if `false`, is not case sensitive
+    // - if `'smart'`, is case sensitive if the query string
+    //   contains uppercase characters
+    "menu.caseSensitive": string | boolean
 
     // Output path to save screenshots and recordings
     "recorder.outputPath": string

--- a/browser/src/Services/Configuration/IConfigurationValues.ts
+++ b/browser/src/Services/Configuration/IConfigurationValues.ts
@@ -112,6 +112,13 @@ export interface IConfigurationValues {
     // "editor.quickOpen.execCommand": "dir /s /b"
     "editor.quickOpen.execCommand": string | null
 
+    // Case-sensitivity strategy for quick-open filtering:
+    // - if `true`, is case sensitive
+    // - if `false`, is not case sensitive
+    // - if `'smart'`, is case sensitive if the query string
+    //   contains uppercase characters
+    "editor.quickOpen.caseSensitive": string | boolean
+
     "editor.fullScreenOnStart": boolean
     "editor.maximizeScreenOnStart": boolean
 

--- a/browser/src/Services/Menu/MenuReducer.ts
+++ b/browser/src/Services/Menu/MenuReducer.ts
@@ -89,7 +89,7 @@ const shouldFilterbeCaseSensitive = (searchString: string): boolean => {
     // One option is to plumb through the configuration setting
     // from the top-level, but it might be worth extracting
     // out the filter strategy in general.
-    const caseSensitivitySetting = configuration.getValue("editor.quickOpen.caseSensitive")
+    const caseSensitivitySetting = configuration.getValue("menu.caseSensitive")
 
     if (caseSensitivitySetting === false) {
         return false

--- a/browser/src/Services/Menu/MenuReducer.ts
+++ b/browser/src/Services/Menu/MenuReducer.ts
@@ -7,6 +7,8 @@
 import * as Fuse from "fuse.js"
 import * as sortBy from "lodash/sortBy"
 
+import { configuration } from "./../../Services/Configuration"
+
 import * as Actions from "./MenuActions"
 import * as State from "./MenuState"
 
@@ -79,6 +81,32 @@ export function popupMenuReducer(s: State.IMenu | null, a: any): State.IMenu {
     }
 }
 
+const shouldFilterbeCaseSensitive = (searchString: string): boolean => {
+
+    // TODO: Technically, this makes the reducer 'impure',
+    // which is not ideal - need to refactor eventually.
+    //
+    // One option is to plumb through the configuration setting
+    // from the top-level, but it might be worth extracting
+    // out the filter strategy in general.
+    const caseSensitivitySetting = configuration.getValue("editor.quickOpen.caseSensitive")
+
+    if (caseSensitivitySetting === false) {
+        return false
+    } else if (caseSensitivitySetting === true) {
+        return true
+    } else {
+        // "Smart" casing strategy
+        // If the string is all lower-case, not case sensitive..
+        if (searchString === searchString.toLowerCase()) {
+            return false
+        // Otherwise, it is case sensitive..
+        } else {
+            return true
+        }
+    }
+}
+
 export function filterMenuOptions(options: Oni.Menu.MenuOption[], searchString: string): State.IMenuOptionWithHighlights[] {
 
     if (!searchString) {
@@ -104,6 +132,7 @@ export function filterMenuOptions(options: Oni.Menu.MenuOption[], searchString: 
             name: "detail",
             weight: 0.4,
         }],
+        caseSensitive: shouldFilterbeCaseSensitive(searchString),
         include: ["matches"],
     }
 
@@ -111,16 +140,17 @@ export function filterMenuOptions(options: Oni.Menu.MenuOption[], searchString: 
     const searchSet = new Set(searchString)
 
     // remove any items that don't have all the characters from searchString
+    // For this first pass, ignore case
     const filteredOptions = options.filter((o) => {
 
         if (!o.label && !o.detail) {
             return false
         }
 
-        const combined = o.label + o.detail
+        const combined = o.label.toLowerCase() + o.detail.toLowerCase()
 
         for (const c of searchSet) {
-            if (combined.indexOf(c) === -1) {
+            if (combined.indexOf(c.toLowerCase()) === -1) {
                 return false
             }
         }


### PR DESCRIPTION
__Issue:__ The 'case-sensitivity' behavior of the QuickOpen is not very clear, and it is even less clear on how you can change the behavior to get preferred functionality (more discussion on this in #825).

__Fix:__ This changes adds a new setting - `editor.quickOpen.caseSensitive` that accepts either a `boolean` value or `smart`. This change makes the pre-filter step case-agnostic, and then uses this setting for running the `fusejs` filter step.