### PR TITLE
Proposal for #783 - Configuration options for tabs

### DIFF
--- a/browser/src/Services/Configuration/DefaultConfiguration.ts
+++ b/browser/src/Services/Configuration/DefaultConfiguration.ts
@@ -81,6 +81,9 @@ const BaseConfiguration: IConfigurationValues = {
 
     "tabs.enabled": true,
     "tabs.showVimTabs": false,
+    "tabs.height": "2.5em",
+    "tabs.maxWidth": "30em",
+    "tabs.wrap": false,
 }
 
 const MacConfigOverrides: Partial<IConfigurationValues> = {

--- a/browser/src/Services/Configuration/IConfigurationValues.ts
+++ b/browser/src/Services/Configuration/IConfigurationValues.ts
@@ -134,4 +134,15 @@ export interface IConfigurationValues {
 
     "tabs.enabled": boolean
     "tabs.showVimTabs": boolean
+
+    // Height of individual tabs in the tab strip
+    "tabs.height": string
+
+    // Maximum width of a tab
+    "tabs.maxWidth": string
+
+    // Whether or not tabs should wrap.
+    // If `false`, a scrollbar will be shown.
+    // If `true`, will wrap the tabs.
+    "tabs.wrap": boolean
 }

--- a/browser/src/UI/components/Tabs.less
+++ b/browser/src/UI/components/Tabs.less
@@ -27,11 +27,8 @@
     align-items: flex-end;
 
     width: 100%;
-    max-height: 48px;
-    min-height: 32px;
     color: #c8c8c8;
     background-color: rgba(0, 0, 0, 0.2);
-    overflow-x: auto;
 }
 
 .tab {
@@ -41,10 +38,8 @@
     justify-content: center;
     cursor: pointer;
 
-    height: 32px;
     flex: 0 0 auto;
 
-    max-width: 350px;
     background-color: rgb(40, 44, 52);
     opacity: 0.6;
     transition: opacity 0.25s;

--- a/browser/src/UI/components/Tabs.tsx
+++ b/browser/src/UI/components/Tabs.tsx
@@ -54,11 +54,11 @@ export class Tabs extends React.PureComponent<ITabsProps, void> {
         }
 
         const wrapStyle: React.CSSProperties = {
-            flexWrap: "wrap"
+            flexWrap: "wrap",
         }
 
         const scrollStyle: React.CSSProperties = {
-            overflowX: "auto"
+            overflowX: "auto",
         }
 
         const overflowStyle = this.props.shouldWrap ? wrapStyle : scrollStyle

--- a/browser/src/UI/components/Tabs.tsx
+++ b/browser/src/UI/components/Tabs.tsx
@@ -41,6 +41,10 @@ export interface ITabsProps {
 
     backgroundColor: string
     foregroundColor: string
+
+    shouldWrap: boolean
+    maxWidth: string
+    height: string
 }
 
 export class Tabs extends React.PureComponent<ITabsProps, void> {
@@ -49,7 +53,18 @@ export class Tabs extends React.PureComponent<ITabsProps, void> {
             return null
         }
 
-        const tabBorderStyle = {
+        const wrapStyle: React.CSSProperties = {
+            flexWrap: "wrap"
+        }
+
+        const scrollStyle: React.CSSProperties = {
+            overflowX: "auto"
+        }
+
+        const overflowStyle = this.props.shouldWrap ? wrapStyle : scrollStyle
+
+        const tabBorderStyle: React.CSSProperties = {
+            ...overflowStyle,
             "borderBottom": `4px solid ${this.props.backgroundColor}`,
         }
 
@@ -61,6 +76,8 @@ export class Tabs extends React.PureComponent<ITabsProps, void> {
                 onClickClose={() => this._onClickClose(t.id)}
                 backgroundColor={this.props.backgroundColor}
                 foregroundColor={this.props.foregroundColor}
+                height={this.props.height}
+                maxWidth={this.props.maxWidth}
             />
         })
 
@@ -84,6 +101,9 @@ export interface ITabPropsWithClick extends ITabProps {
 
     backgroundColor: string
     foregroundColor: string
+
+    height: string
+    maxWidth: string
 }
 
 export const Tab = (props: ITabPropsWithClick) => {
@@ -97,6 +117,8 @@ export const Tab = (props: ITabPropsWithClick) => {
     const style = {
         backgroundColor: props.backgroundColor,
         color: props.foregroundColor,
+        maxWidth: props.maxWidth,
+        height: props.height,
     }
 
     return <div className={cssClasses} title={props.description} style={style}>
@@ -164,6 +186,10 @@ const mapStateToProps = (state: State.IState, ownProps: ITabContainerProps): ITa
 
     const visible = state.configuration["tabs.enabled"]
 
+    const height = state.configuration["tabs.height"]
+    const maxWidth = state.configuration["tabs.maxWidth"]
+    const shouldWrap = state.configuration["tabs.wrap"]
+
     const selectFunc = shouldUseVimTabs ? ownProps.onTabSelect : ownProps.onBufferSelect
     const closeFunc = shouldUseVimTabs ? ownProps.onTabClose : ownProps.onBufferClose
 
@@ -172,6 +198,9 @@ const mapStateToProps = (state: State.IState, ownProps: ITabContainerProps): ITa
         foregroundColor: state.foregroundColor,
         onSelect: selectFunc,
         onClose: closeFunc,
+        height,
+        maxWidth,
+        shouldWrap,
         visible,
         tabs,
     }


### PR DESCRIPTION
Related to #827 - this adds the following customization options:
- `tabs.height`
- `tabs.maxWidth`
- `tabs.wrap`

I think it makes sense to make this customizable, because some people might prefer the Vim-style line sizing. Setting `tabs.height` to `1em` or `1.5em` would be closer to that.

@badosu  - let me know how you feel about these customization settings.