### PR TITLE
Include `ocaml-language-server` and default configuration for Windows

### DIFF
--- a/browser/src/Services/Configuration/DefaultConfiguration.ts
+++ b/browser/src/Services/Configuration/DefaultConfiguration.ts
@@ -10,7 +10,7 @@ import * as path from "path"
 import * as Platform from "./../../Platform"
 
 import { IConfigurationValues } from "./IConfigurationValues"
-import { ocamlLanguageServerPath, ocamlAndReasonConfiguration } from "./ReasonConfiguration"
+import { ocamlAndReasonConfiguration, ocamlLanguageServerPath } from "./ReasonConfiguration"
 
 const noop = () => { } // tslint:disable-line no-empty
 
@@ -78,7 +78,6 @@ const BaseConfiguration: IConfigurationValues = {
     "language.python.languageServer.command": "pyls",
     "language.cpp.languageServer.command": "clangd",
     "language.c.languageServer.command": "clangd",
-
 
     "language.reason.languageServer.command": ocamlLanguageServerPath,
     "language.reason.languageServer.arguments": ["--stdio"],

--- a/browser/src/Services/Configuration/DefaultConfiguration.ts
+++ b/browser/src/Services/Configuration/DefaultConfiguration.ts
@@ -10,38 +10,9 @@ import * as path from "path"
 import * as Platform from "./../../Platform"
 
 import { IConfigurationValues } from "./IConfigurationValues"
+import { ocamlLanguageServerPath, ocamlAndReasonConfiguration } from "./ReasonConfiguration"
 
 const noop = () => { } // tslint:disable-line no-empty
-
-const ocamlLanguageServerPath = Platform.isWindows() ? path.join(__dirname, "node_modules", ".bin", "ocaml-language-server.cmd") : path.join(__dirname, "node_modules", ".bin", "ocaml-language-server")
-
-const ocamlAndReasonConfiguration = {
-    reason: {
-        codelens: {
-            enabled: true,
-            unicode: true,
-        },
-        bsb: {
-            enabled: true,
-        },
-        debounce: {
-            linter: 500,
-        },
-        diagnostic: {
-            tools: ["merlin"],
-        },
-        path: {
-            bsb: "bash -ic bsb",
-            ocamlfind: "bash -ic ocamlfind",
-            ocamlmerlin: "bash -ic ocamlmerlin",
-            opam: "bash -ic opam",
-            rebuild: "bash -ic rebuild",
-            refmt: "bash -ic refmt",
-            refmterr: "bash -ic refmterr",
-            rtop: "bash -ic rtop",
-        }
-    }
-}
 
 const BaseConfiguration: IConfigurationValues = {
     activate: noop,

--- a/browser/src/Services/Configuration/DefaultConfiguration.ts
+++ b/browser/src/Services/Configuration/DefaultConfiguration.ts
@@ -13,6 +13,7 @@ import { IConfigurationValues } from "./IConfigurationValues"
 
 const noop = () => { } // tslint:disable-line no-empty
 
+const ocamlLanguageServerPath = Platform.isWindows() ? path.join(__dirname, "node_modules", ".bin", "ocaml-language-server.cmd") : path.join(__dirname, "node_modules", ".bin", "ocaml-language-server")
 
 const ocamlAndReasonConfiguration = {
     reason: {
@@ -108,12 +109,12 @@ const BaseConfiguration: IConfigurationValues = {
     "language.c.languageServer.command": "clangd",
 
 
-    "language.reason.languageServer.command": "ocaml-language-server",
+    "language.reason.languageServer.command": ocamlLanguageServerPath,
     "language.reason.languageServer.arguments": ["--stdio"],
     "language.reason.languageServer.rootFiles": [".merlin", "bsconfig.json"],
     "language.reason.languageServer.configuration": ocamlAndReasonConfiguration,
 
-    "language.ocaml.languageServer.command": "ocaml-language-server",
+    "language.ocaml.languageServer.command": ocamlLanguageServerPath,
     "language.ocaml.languageServer.arguments": ["--stdio"],
     "language.ocaml.languageServer.configuration": ocamlAndReasonConfiguration,
 

--- a/browser/src/Services/Configuration/DefaultConfiguration.ts
+++ b/browser/src/Services/Configuration/DefaultConfiguration.ts
@@ -13,6 +13,35 @@ import { IConfigurationValues } from "./IConfigurationValues"
 
 const noop = () => { } // tslint:disable-line no-empty
 
+
+const ocamlAndReasonConfiguration = {
+    reason: {
+        codelens: {
+            enabled: true,
+            unicode: true,
+        },
+        bsb: {
+            enabled: true,
+        },
+        debounce: {
+            linter: 500,
+        },
+        diagnostic: {
+            tools: ["merlin"],
+        },
+        path: {
+            bsb: "bash -ic bsb",
+            ocamlfind: "bash -ic ocamlfind",
+            ocamlmerlin: "bash -ic ocamlmerlin",
+            opam: "bash -ic opam",
+            rebuild: "bash -ic rebuild",
+            refmt: "bash -ic refmt",
+            refmterr: "bash -ic refmterr",
+            rtop: "bash -ic rtop",
+        }
+    }
+}
+
 const BaseConfiguration: IConfigurationValues = {
     activate: noop,
     deactivate: noop,
@@ -77,6 +106,16 @@ const BaseConfiguration: IConfigurationValues = {
     "language.python.languageServer.command": "pyls",
     "language.cpp.languageServer.command": "clangd",
     "language.c.languageServer.command": "clangd",
+
+
+    "language.reason.languageServer.command": "ocaml-language-server",
+    "language.reason.languageServer.arguments": ["--stdio"],
+    "language.reason.languageServer.rootFiles": [".merlin", "bsconfig.json"],
+    "language.reason.languageServer.configuration": ocamlAndReasonConfiguration,
+
+    "language.ocaml.languageServer.command": "ocaml-language-server",
+    "language.ocaml.languageServer.arguments": ["--stdio"],
+    "language.ocaml.languageServer.configuration": ocamlAndReasonConfiguration,
 
     "menu.caseSensitive": "smart",
 

--- a/browser/src/Services/Configuration/ReasonConfiguration.ts
+++ b/browser/src/Services/Configuration/ReasonConfiguration.ts
@@ -1,7 +1,7 @@
 /**
- * DefaultConfiguration.ts
+ * ReasonConfiguration.ts
  *
- * Specifies Oni default settings
+ * Settings for ocaml / reason language server
  */
 
 import * as path from "path"
@@ -37,6 +37,6 @@ export const ocamlAndReasonConfiguration = {
             refmt: wrapCommand("refmt"),
             refmterr: wrapCommand("refmterr"),
             rtop: wrapCommand("rtop"),
-        }
-    }
+        },
+    },
 }

--- a/browser/src/Services/Configuration/ReasonConfiguration.ts
+++ b/browser/src/Services/Configuration/ReasonConfiguration.ts
@@ -1,0 +1,42 @@
+/**
+ * DefaultConfiguration.ts
+ *
+ * Specifies Oni default settings
+ */
+
+import * as path from "path"
+
+import * as Platform from "./../../Platform"
+
+export const ocamlLanguageServerPath = Platform.isWindows() ? path.join(__dirname, "node_modules", ".bin", "ocaml-language-server.cmd") : path.join(__dirname, "node_modules", ".bin", "ocaml-language-server")
+
+// If Windows, wrap in `bash -ic` to support WSL
+const wrapCommand = Platform.isWindows() ? (str: string) => "bash -ic " + str : (str: string) => str
+
+export const ocamlAndReasonConfiguration = {
+    reason: {
+        codelens: {
+            enabled: true,
+            unicode: true,
+        },
+        bsb: {
+            enabled: true,
+        },
+        debounce: {
+            linter: 500,
+        },
+        diagnostic: {
+            tools: ["merlin"],
+        },
+        path: {
+            bsb: wrapCommand("bsb"),
+            ocamlfind: wrapCommand("ocamlfind"),
+            ocamlmerlin: wrapCommand("ocamlmerlin"),
+            opam: wrapCommand("opam"),
+            rebuild: wrapCommand("rebuild"),
+            refmt: wrapCommand("refmt"),
+            refmterr: wrapCommand("refmterr"),
+            rtop: wrapCommand("rtop"),
+        }
+    }
+}

--- a/browser/src/Services/Language/LanguageClientProcess.ts
+++ b/browser/src/Services/Language/LanguageClientProcess.ts
@@ -81,7 +81,8 @@ export class LanguageClientProcess {
 
     constructor(
         private _serverOptions: ServerRunOptions,
-        private _initializationOptions: InitializationOptions) {
+        private _initializationOptions: InitializationOptions,
+        private _configuration: any = null) {
     }
 
     public async ensureActive(fileName: string): Promise<rpc.MessageConnection> {
@@ -149,15 +150,21 @@ export class LanguageClientProcess {
             capabilities: {},
         }
 
-        return this._connection.sendRequest("initialize", oniLanguageClientParams)
-            .then((response: any) => {
-                Log.info(`[LanguageClientManager]: Initialized`)
-                if (response && response.capabilities) {
-                    this._serverCapabilities = response.capabilities
-                }
-            }, (err) => {
-                Log.error(err)
-            })
+        try {
+            const response: any = await this._connection.sendRequest("initialize", oniLanguageClientParams)
+            Log.info(`[LanguageClientManager]: Initialized`)
+            if (response && response.capabilities) {
+                this._serverCapabilities = response.capabilities
+            }
+
+            if (this._configuration) {
+                Log.verbose("[LanguageClientProcess]: Sending configuration")
+                this._connection.sendNotification("workspace/didChangeConfiguration", { settings: this._configuration })
+            }
+        }
+        catch (ex) {
+            Log.error(ex)
+        }
     }
 
     private _end(): void {

--- a/browser/src/Services/Language/LanguageClientProcess.ts
+++ b/browser/src/Services/Language/LanguageClientProcess.ts
@@ -161,8 +161,7 @@ export class LanguageClientProcess {
                 Log.verbose("[LanguageClientProcess]: Sending configuration")
                 this._connection.sendNotification("workspace/didChangeConfiguration", { settings: this._configuration })
             }
-        }
-        catch (ex) {
+        } catch (ex) {
             Log.error(ex)
         }
     }

--- a/browser/src/Services/Language/LanguageConfiguration.ts
+++ b/browser/src/Services/Language/LanguageConfiguration.ts
@@ -20,6 +20,7 @@ export interface ILightweightLanguageServerConfiguration {
     arguments?: string[]
     command?: string
     rootFiles?: string[]
+    configuration?: any
 }
 
 export const createLanguageClientsFromConfiguration = (configurationValues: { [key: string]: any }) => {
@@ -74,6 +75,7 @@ const createLanguageClientFromConfig = (language: string, config: ILightweightLa
     const lightweightCommand = config.languageServer.command
     const rootFiles = config.languageServer.rootFiles
     const args = config.languageServer.arguments || []
+    const configuration = config.languageServer.configuration || null
 
     Log.info(`[Language Manager - Config] Registering info for language: ${language} - command: ${config.languageServer.command}`)
 
@@ -94,6 +96,6 @@ const createLanguageClientFromConfig = (language: string, config: ILightweightLa
     const initializationOptions: InitializationOptions = {
         rootPath: pathResolver,
     }
-    const languageClient = new LanguageClient(language, new LanguageClientProcess(serverRunOptions, initializationOptions))
+    const languageClient = new LanguageClient(language, new LanguageClientProcess(serverRunOptions, initializationOptions, configuration))
     languageManager.registerLanguageClient(language, languageClient)
 }

--- a/browser/src/Services/Language/LanguageManager.ts
+++ b/browser/src/Services/Language/LanguageManager.ts
@@ -112,7 +112,6 @@ export class LanguageManager {
             return null
         })
 
-
         listenForWorkspaceEdits(this)
     }
 

--- a/browser/src/Services/Language/LanguageManager.ts
+++ b/browser/src/Services/Language/LanguageManager.ts
@@ -95,6 +95,10 @@ export class LanguageManager {
             return this.sendLanguageServerNotification(language, filePath, "textDocument/didSave", Helpers.pathToTextDocumentIdentifierParms(filePath))
         })
 
+        this.subscribeToLanguageServerNotification("window/showMessage", (args) => {
+            Log.warn("window/showMessage not implemented: " + JSON.stringify(args.toString()))
+        })
+
         this.subscribeToLanguageServerNotification("window/logMessage", (args) => {
             logVerbose(args)
         })
@@ -102,6 +106,12 @@ export class LanguageManager {
         this.subscribeToLanguageServerNotification("telemetry/event", (args) => {
             logDebug(args)
         })
+
+        this.handleLanguageServerRequest("window/showMessageRequest", async (req) => {
+            logVerbose(req)
+            return null
+        })
+
 
         listenForWorkspaceEdits(this)
     }

--- a/package.json
+++ b/package.json
@@ -111,9 +111,10 @@
     "keyboard-layout": "2.0.13",
     "minimist": "1.2.0",
     "msgpack-lite": "0.1.26",
-    "ocaml-language-server": "^1.0.1",
+    "ocaml-language-server": "1.0.1",
     "typescript": "2.5.3",
     "vscode-jsonrpc": "3.4.1",
+    "vscode-languageserver": "3.4.3",
     "vscode-languageserver-types": "3.4.0",
     "vscode-ripgrep": "0.6.0-patch.0"
   },

--- a/package.json
+++ b/package.json
@@ -111,6 +111,7 @@
     "keyboard-layout": "2.0.13",
     "minimist": "1.2.0",
     "msgpack-lite": "0.1.26",
+    "ocaml-language-server": "^1.0.1",
     "typescript": "2.5.3",
     "vscode-jsonrpc": "3.4.1",
     "vscode-languageserver-types": "3.4.0",


### PR DESCRIPTION
- Bring in `ocaml-language-server` so that ocaml / reason have first-class support in Oni (ideally, zero-configuration, although merlin still needs to be set up properly).