### PR TITLE
Fix #843 - Oni freezes when using Neovim's completion popup menu

### DIFF
--- a/browser/src/Editor/NeovimPopupMenu.tsx
+++ b/browser/src/Editor/NeovimPopupMenu.tsx
@@ -6,17 +6,10 @@
 
 import * as React from "react"
 
-import * as types from "vscode-languageserver-types"
-
 import { IEvent } from "./../Event"
 import { INeovimCompletionInfo, INeovimCompletionItem } from "./../neovim"
 
-import { editorManager } from "./../Services/EditorManager"
-
-import * as Coordinates from "./../UI/Coordinates"
-
 import * as UI from "./../UI"
-import * as Selectors from "./../UI/Selectors"
 
 import { ContextMenuView, IContextMenuItem } from "./../Services/ContextMenu"
 
@@ -24,12 +17,12 @@ const mapNeovimCompletionItemToContextMenuItem = (item: INeovimCompletionItem, i
     label: item.word,
     detail: item.menu,
     documentation: (idx + 1).toString() + " of " + totalLength.toString(),
+    icon: "align-right",
 })
 
 export class NeovimPopupMenu {
 
     private _lastItems: IContextMenuItem[] = []
-    private _position: Coordinates.PixelSpacePoint
 
     constructor(
         private _popupMenuShowEvent: IEvent<INeovimCompletionInfo>,
@@ -38,24 +31,6 @@ export class NeovimPopupMenu {
     ) {
 
         this._popupMenuShowEvent.subscribe((completionInfo) => {
-            // In some cases, when the popup is being shown, there will be a distracting flicker.
-            // This is due to the fact that the cursor moves to the command/message line
-            // to show the "Match 1 of X" maessage.
-            //
-            // Since the `<CursorPositioner>` is based on the cursor position,
-            // this can cause flickering as it flips down.
-            //
-            // To avoid this, we'll grab the current pixel position of the cursor,
-            // and pin the completion menu there.j
-            const store = UI.store.getState() as any
-            const activeWindow = Selectors.getActiveWindow(store)
-            const cursor = editorManager.activeEditor.activeBuffer.cursor
-            const pos = types.Position.create(cursor.line, cursor.column)
-
-            const screenSpace = activeWindow.bufferToScreen(pos)
-            const pixelSpace = activeWindow.screenToPixel(screenSpace)
-
-            this._position = pixelSpace
             this._lastItems = completionInfo.items.map((i, idx) => mapNeovimCompletionItemToContextMenuItem(i, idx, completionInfo.items.length))
 
             this._renderCompletionMenu(completionInfo.selectedIndex)
@@ -84,7 +59,7 @@ export class NeovimPopupMenu {
 
         const completionElement = <ContextMenuView visible={true} base={""} entries={itemsToRender} selectedIndex={adjustedIndex} backgroundColor={"black"} foregroundColor={"white"} />
         UI.Actions.showToolTip("nvim-popup", completionElement, {
-                position: this._position,
+                position: null,
                 openDirection: 2,
                 padding: "0px",
             })

--- a/browser/src/Services/ContextMenu/ContextMenuComponent.tsx
+++ b/browser/src/Services/ContextMenu/ContextMenuComponent.tsx
@@ -21,6 +21,7 @@ export interface IContextMenuItem {
     label: string
     detail?: string
     documentation?: string
+    icon?: string
 }
 
 export interface IContextMenuProps {


### PR DESCRIPTION
__Issue:__ When using the Neovim popup menu, Oni could crash and not respond to input.

__Defect:__ There was special logic to position the popup menu that wasn't airtight. This was to address a flickering issue - with `position: null`, the completion menu shows relative to the cursor. The problem is, the cursor moves to the echo line during completions, so this can cause a flicker.

__Fix:__ The flickering is better than Oni crashing, so revert that special logic - we can address the flickering separately if is it still an issue.