### PR TITLE
Completion bug fixes

### DIFF
--- a/browser/src/Services/AutoCompletionUtility.ts
+++ b/browser/src/Services/AutoCompletionUtility.ts
@@ -33,8 +33,16 @@ export function replacePrefixWithCompletion(bufferLine: string, basePosition: nu
 }
 
 export interface CompletionMeetResult {
+    // Position - where the meet starts
     position: number
+
+    // PositionToQuery - where the query request should start
+    positionToQuery: number
+
+    // Base - the currentg prefix of the completion
     base: string
+
+    // Whether or not completiosn should be expanded / queriried
     shouldExpandCompletions: boolean
 }
 
@@ -64,17 +72,17 @@ export function getCompletionMeet(line: string, cursorColumn: number, characterM
         col--
     }
 
-    const basePos = col
+    const basePos = col + 1
 
-    const isFromTriggerCharacter = doesCharacterMatchTriggerCharacters(line[basePos], completionTriggerCharacters)
+    const isFromTriggerCharacter = doesCharacterMatchTriggerCharacters(line[basePos - 1], completionTriggerCharacters)
 
     const shouldExpandCompletions = currentPrefix.length > 0 || isFromTriggerCharacter
 
-    // If the expansion is due to a letter, start the match at the letter position
-    const position = isFromTriggerCharacter ? basePos : basePos + 1
+    const positionToQuery = isFromTriggerCharacter ? basePos : basePos + 1
 
     return {
-        position: position + 1,
+        position: basePos,
+        positionToQuery,
         base: currentPrefix,
         shouldExpandCompletions,
     }

--- a/browser/src/Services/Menu/MenuFilter.ts
+++ b/browser/src/Services/Menu/MenuFilter.ts
@@ -78,7 +78,10 @@ export function filterMenuOptions(options: Oni.Menu.MenuOption[], searchString: 
             return false
         }
 
-        const combined = o.label.toLowerCase() + o.detail.toLowerCase()
+        const label = o.label ? o.label.toLowerCase() : ""
+        const detail = o.detail ? o.detail.toLowerCase() : ""
+
+        const combined = label + detail
 
         for (const c of searchSet) {
             if (combined.indexOf(c.toLowerCase()) === -1) {


### PR DESCRIPTION
Fix a couple additional issues with completion:

- Base is not correct. I tweaked the base position as some language servers would not return completions if there is no base, but the existing code made the assumption that the meet base was the same as the query position, so that needed to be decoupled.
- The menu logic merged in from master assumed that `label` and `detail` were always present - this is problematic for symbol search.
- The completions would eventually crash (hosing the observable) if the filterText was null