### PR TITLE
Fix some configuration settings in the LSP providers

### DIFF
--- a/browser/src/Services/Configuration/DefaultConfiguration.ts
+++ b/browser/src/Services/Configuration/DefaultConfiguration.ts
@@ -23,8 +23,6 @@ const BaseConfiguration: IConfigurationValues = {
     "debug.persistOnNeovimExit": false,
     "debug.detailedSessionLogging": false,
 
-    "experimental.enableLanguageServerFromConfig": false,
-
     "oni.audio.bellUrl": path.join(__dirname, "audio", "beep.wav"),
 
     "oni.useDefaultConfig": true,

--- a/browser/src/Services/Configuration/IConfigurationValues.ts
+++ b/browser/src/Services/Configuration/IConfigurationValues.ts
@@ -25,8 +25,6 @@ export interface IConfigurationValues {
 
     // Experimental feature flags
 
-    "experimental.enableLanguageServerFromConfig": boolean
-
     // Production settings
 
     // Bell sound effect to use

--- a/browser/src/Services/Language/Definition.ts
+++ b/browser/src/Services/Language/Definition.ts
@@ -35,9 +35,9 @@ export const initDefinitionUI = (shouldHide$: Observable<any>, shouldUpdate$: Ob
                         return
                     }
 
-                    UI.Actions.setDefinition(definitionResult.token, result[0]) 
+                    UI.Actions.setDefinition(definitionResult.token, result[0])
                 } else {
-                    UI.Actions.setDefinition(definitionResult.token, result) 
+                    UI.Actions.setDefinition(definitionResult.token, result)
                 }
             }
         })

--- a/browser/src/Services/Language/Definition.ts
+++ b/browser/src/Services/Language/Definition.ts
@@ -24,7 +24,21 @@ export const initDefinitionUI = (shouldHide$: Observable<any>, shouldUpdate$: Ob
             if (!definitionResult || !definitionResult.result) {
                 UI.Actions.hideDefinition()
             } else {
-                UI.Actions.setDefinition(definitionResult.token, definitionResult.result)
+                const result: types.Location | types.Location[] = definitionResult.result
+
+                if (!result) {
+                    return
+                }
+
+                if (result instanceof Array) {
+                    if (!result.length) {
+                        return
+                    }
+
+                    UI.Actions.setDefinition(definitionResult.token, result[0]) 
+                } else {
+                    UI.Actions.setDefinition(definitionResult.token, result) 
+                }
             }
         })
 }

--- a/browser/src/Services/Language/QuickInfo.ts
+++ b/browser/src/Services/Language/QuickInfo.ts
@@ -8,6 +8,7 @@ import * as types from "vscode-languageserver-types"
 import * as Log from "./../../Log"
 import * as Helpers from "./../../Plugins/Api/LanguageClient/LanguageClientHelpers"
 
+import { configuration } from "./../Configuration"
 import { editorManager } from "./../EditorManager"
 
 import { languageManager } from "./LanguageManager"
@@ -16,6 +17,10 @@ export const getQuickInfo = async (): Promise<types.Hover> => {
     const buffer = editorManager.activeEditor.activeBuffer
     const { language, filePath } = buffer
     const { line, column } = buffer.cursor
+
+    if (!configuration.getValue("editor.quickInfo.enabled")) {
+        return null
+    }
 
     if (languageManager.isLanguageServerAvailable(language)) {
 

--- a/vim/core/oni-core-interop/plugin/init.vim
+++ b/vim/core/oni-core-interop/plugin/init.vim
@@ -151,7 +151,7 @@ function! OniNextWindow( direction )
   endif
 endfunction
 
-nnoremap gd :call OniCommand("language.gotoDefinition")<CR>
+nnoremap <silent> gd :<C-u>call OniCommand("language.gotoDefinition")<CR>
 nnoremap <silent> <C-w>h :<C-u>call OniNextWindow('h')<CR>
 nnoremap <silent> <C-w>j :<C-u>call OniNextWindow('j')<CR>
 nnoremap <silent> <C-w>k :<C-u>call OniNextWindow('k')<CR>


### PR DESCRIPTION
- Remove the `experimental.enableLanguageServerFromConfig` setting as it is now enabled by default
- Wire up `editor.quickInfo.enabled` and `editor.completions.enabled`