### PR TITLE
Fix #846 - Autocompletion is opening outside bounds near the top

### DIFF
--- a/browser/src/UI/components/CursorPositioner.tsx
+++ b/browser/src/UI/components/CursorPositioner.tsx
@@ -44,6 +44,8 @@ export interface ICursorPositionerViewState {
     isFullWidth: boolean
     shouldOpenDownward: boolean,
     adjustedX: number
+    lastMeasuredX: number,
+    lastMeasuredY: number,
     lastMeasuredHeight: number,
     lastMeasuredWidth: number,
 }
@@ -55,6 +57,8 @@ const InitialState = {
     shouldOpenDownward: false,
     adjustedX: 0,
 
+    lastMeasuredX: -1,
+    lastMeasuredY: -1,
     lastMeasuredHeight: 0,
     lastMeasuredWidth: 0,
 }
@@ -154,7 +158,9 @@ export class CursorPositionerView extends React.PureComponent<ICursorPositionerV
         if (element) {
             const rect = element.getBoundingClientRect()
 
-            if (rect.height <= this.state.lastMeasuredHeight
+            if (rect.left === this.state.lastMeasuredX
+                && rect.top === this.state.lastMeasuredY
+                && rect.height <= this.state.lastMeasuredHeight
                && rect.width <= this.state.lastMeasuredWidth) {
                 return
             }
@@ -182,6 +188,8 @@ export class CursorPositionerView extends React.PureComponent<ICursorPositionerV
                     shouldOpenDownward,
                     adjustedX,
                     isMeasured: true,
+                    lastMeasuredX: rect.left,
+                    lastMeasuredY: rect.top,
                     lastMeasuredWidth: rect.width,
                     lastMeasuredHeight: rect.height,
                 })


### PR DESCRIPTION
__Issue:__ Screenshot in #846 describes it well - the autocompletion menu opens above the window when it is near the top (it should be opening below).

__Defect:__ This is related to the cursor-movement issues we have with the cursor moving to the bottom. The completion menu is wrapped in the `<CursorPositioner />` react component, which is a helper to intelligent move UI above/below the cursor depending on how close it is to the bounds. However, in this case, it is measuring when the cursor is at the bottom of the screen, and then not updating the measurement later when it is moved to the top.

__Fix:__ There is an optimization to not re-measure if the width/height haven't changed. We should measure, though, if the x/y have changed, so update that condition such that we skip remeasuring _only_ if the previous x/y condition are the same, and the width/height is less than or equal to before.