### PR TITLE
Automation: Increase test timeout

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,11 +33,12 @@
       "!build",
       "!examples",
       "!lib_test",
-      "!test"
+      "!test",
+      "!node_modules/typescript"
     ],
     "extraResources": [{
-        "from": "node_modules/typescript/lib",
-        "to": "app/node_modules/typescript/lib"
+        "from": "node_modules/typescript",
+        "to": "app/node_modules/typescript"
     }],
     "mac": {
       "artifactName": "${productName}-${version}-osx.${ext}",

--- a/test/CiTests.ts
+++ b/test/CiTests.ts
@@ -41,7 +41,7 @@ describe("ci tests", function() { // tslint:disable-line only-arrow-functions
             oni.client.execute("Oni.automation.runTest('" + normalizedTestPath + "')")
 
             console.log("Waiting for result...") // tslint:disable-line
-            await oni.client.waitForExist(".automated-test-result")
+            await oni.client.waitForExist(".automated-test-result", 30000)
             const resultText = await oni.client.getText(".automated-test-result")
             console.log("Got result: " + resultText) // tslint:disable-line
 


### PR DESCRIPTION
__Issue:__ The new CiTest fails intermittently, because it is waiting for the 'in-proc' test to complete running, within 500ms (the default `waitForExist` timeout is 500ms) - this timeout is too aggressive to run the test in its entirety.